### PR TITLE
feat: add swagger v1 json docs

### DIFF
--- a/docs/source/content/user_documentation/developer/basyx_java_v1/index.md
+++ b/docs/source/content/user_documentation/developer/basyx_java_v1/index.md
@@ -5,6 +5,16 @@
 * [Java SDK Eventing for AAS](./extensions/eventing.md)
 * [Knowledge Base](./knowledge_base/index.md)
 
+## BaSyx Swagger API Documentation
+
+Below are the links to download the BaSyx API documentation as JSON files:
+
+- [BaSyx Asset Administration Shell Repository HTTP REST-API](./swagger/basyx_asset_administration_shell_repository_http_rest_api-v1.json)
+- [BaSyx Submodel HTTP REST-API](./swagger/basyx_submodel_http_rest_api-v1.json)
+- [BaSyx Shared Models](./swagger/shared_models-v1.json)
+- [BaSyx Submodel Repository HTTP REST-API](./swagger/basyx_submodel_repository_http_rest_api-v1.json)
+- [BaSyx Asset Administration Shell HTTP REST-API](./swagger/basyx_asset_administration_shell_http_rest_api-v1.json)
+- [BaSyx Registry HTTP REST-API](./swagger/basyx_registry_api-v1.json)
 
 ```{toctree}
 :hidden:

--- a/docs/source/content/user_documentation/developer/basyx_java_v1/swagger/basyx_asset_administration_shell_http_rest_api-v1.json
+++ b/docs/source/content/user_documentation/developer/basyx_java_v1/swagger/basyx_asset_administration_shell_http_rest_api-v1.json
@@ -1,0 +1,1498 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "BaSyx Asset Administration Shell HTTP REST-API",
+    "description" : "The full description of the generic BaSyx Asset Administration Shell HTTP REST-API",
+    "contact" : {
+      "name" : "Constantin Ziesche",
+      "url" : "https://www.bosch.com/de/",
+      "email" : "constantin.ziesche@bosch.com"
+    },
+    "license" : {
+      "name" : "EPL-2.0",
+      "url" : "https://www.eclipse.org/legal/epl-2.0/"
+    },
+    "version" : "v1"
+  },
+  "paths" : {
+    "/aas" : {
+      "get" : {
+        "tags" : [ "AssetAdministrationShell" ],
+        "summary" : "Retrieves the Asset Administration Shell Descriptor",
+        "operationId" : "GetAssetAdministrationShell",
+        "responses" : {
+          "200" : {
+            "description" : "Success",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AssetAdministrationShellDescriptor"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/aas/submodels" : {
+      "get" : {
+        "tags" : [ "AssetAdministrationShell" ],
+        "summary" : "Retrieves all Submodels from the  Asset Administration Shell",
+        "operationId" : "GetSubmodelsFromShell",
+        "responses" : {
+          "200" : {
+            "description" : "Returns a list of found Submodels",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Submodel"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "No Submodel Service Providers found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/aas/submodels/{submodelIdShort}" : {
+      "put" : {
+        "tags" : [ "AssetAdministrationShell" ],
+        "summary" : "Creates or updates a Submodel to an existing Asset Administration Shell",
+        "operationId" : "PutSubmodelToShell",
+        "parameters" : [ {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "The Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's short id",
+            "nullable" : true
+          }
+        } ],
+        "requestBody" : {
+          "description" : "The serialized Submodel object",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Submodel"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "201" : {
+            "description" : "Submodel created successfully",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Submodel"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get" : {
+        "tags" : [ "AssetAdministrationShell" ],
+        "summary" : "Retrieves the Submodel from the Asset Administration Shell",
+        "parameters" : [ {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "The Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's short id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Submodel retrieved successfully",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Submodel"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "No Submodel Service Provider found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "AssetAdministrationShell" ],
+        "summary" : "Deletes a specific Submodel from the Asset Administration Shell",
+        "operationId" : "DeleteSubmodelFromShellByIdShort",
+        "parameters" : [ {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "The Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's short id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "Submodel deleted successfully"
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/aas/submodels/{submodelIdShort}/submodel" : {
+      "get" : {
+        "tags" : [ "AssetAdministrationShell" ],
+        "summary" : "Retrieves the Submodel from the Asset Administration Shell",
+        "operationId" : "GetSubmodelFromShellByIdShort",
+        "parameters" : [ {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "The Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's short id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Submodel retrieved successfully",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Submodel"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "No Submodel Service Provider found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/aas/submodels/{submodelIdShort}/submodel/values" : {
+      "get" : {
+        "tags" : [ "AssetAdministrationShell" ],
+        "summary" : "Retrieves the minimized version of a Submodel, i.e. only the values of SubmodelElements are serialized and returned",
+        "operationId" : "Shell_GetSubmodelValues",
+        "parameters" : [ {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "The Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's short id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Success"
+          },
+          "404" : {
+            "description" : "Submodel not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/aas/submodels/{submodelIdShort}/submodel/submodelElements" : {
+      "get" : {
+        "tags" : [ "AssetAdministrationShell" ],
+        "summary" : "Retrieves all Submodel-Elements from the Submodel",
+        "operationId" : "Shell_GetSubmodelElements",
+        "parameters" : [ {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "The Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's short id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Returns a list of found Submodel-Elements",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/SubmodelElement"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Submodel not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/aas/submodels/{submodelIdShort}/submodel/submodelElements/{seIdShortPath}" : {
+      "put" : {
+        "tags" : [ "AssetAdministrationShell" ],
+        "summary" : "Creates or updates a Submodel-Element at the Submodel",
+        "operationId" : "Shell_PutSubmodelElement",
+        "parameters" : [ {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "The Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's short id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "seIdShortPath",
+          "in" : "path",
+          "description" : "The Submodel-Element's IdShort-Path",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel-Element's IdShort-Path",
+            "nullable" : true
+          }
+        } ],
+        "requestBody" : {
+          "description" : "The Submodel-Element object",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ISubmodelElement"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "201" : {
+            "description" : "Submodel-Element created successfully",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SubmodelElement"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Submodel not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get" : {
+        "tags" : [ "AssetAdministrationShell" ],
+        "summary" : "Retrieves a specific Submodel-Element from the Submodel",
+        "operationId" : "Shell_GetSubmodelElementByIdShort",
+        "parameters" : [ {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "The Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's short id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "seIdShortPath",
+          "in" : "path",
+          "description" : "The Submodel-Element's IdShort-Path",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel-Element's IdShort-Path",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Returns the requested Submodel-Element",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SubmodelElement"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Submodel / Submodel-Element not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "AssetAdministrationShell" ],
+        "summary" : "Deletes a specific Submodel-Element from the Submodel",
+        "operationId" : "Shell_DeleteSubmodelElementByIdShort",
+        "parameters" : [ {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "The Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's short id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "seIdShortPath",
+          "in" : "path",
+          "description" : "The Submodel-Element's IdShort-Path",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel-Element's IdShort-Path",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Success",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "204" : {
+            "description" : "Submodel-Element deleted successfully"
+          },
+          "404" : {
+            "description" : "Submodel / Submodel-Element not found"
+          }
+        }
+      }
+    },
+    "/aas/submodels/{submodelIdShort}/submodel/submodelElements/{seIdShortPath}/value" : {
+      "get" : {
+        "tags" : [ "AssetAdministrationShell" ],
+        "summary" : "Retrieves the value of a specific Submodel-Element from the Submodel",
+        "operationId" : "Shell_GetSubmodelElementValueByIdShort",
+        "parameters" : [ {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "The Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's short id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "seIdShortPath",
+          "in" : "path",
+          "description" : "The Submodel-Element's IdShort-Path",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel-Element's IdShort-Path",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Returns the value of a specific Submodel-Element",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Submodel / Submodel-Element not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "405" : {
+            "description" : "Method not allowed",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "AssetAdministrationShell" ],
+        "summary" : "Updates the Submodel-Element's value",
+        "operationId" : "Shell_PutSubmodelElementValueByIdShort",
+        "parameters" : [ {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "The Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's short id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "seIdShortPath",
+          "in" : "path",
+          "description" : "The Submodel-Element's IdShort-Path",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel-Element's IdShort-Path",
+            "nullable" : true
+          }
+        } ],
+        "requestBody" : {
+          "description" : "The new value",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "object",
+                "description" : "The new value",
+                "nullable" : true
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Submodel-Element's value changed successfully",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ElementValue"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Submodel / Submodel-Element not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "405" : {
+            "description" : "Method not allowed"
+          }
+        }
+      }
+    },
+    "/aas/submodels/{submodelIdShort}/submodel/submodelElements/{idShortPathToOperation}/invoke" : {
+      "post" : {
+        "tags" : [ "AssetAdministrationShell" ],
+        "summary" : "Invokes a specific operation from the Submodel synchronously or asynchronously",
+        "operationId" : "Shell_InvokeOperationByIdShort",
+        "parameters" : [ {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "Submodel's short id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "idShortPathToOperation",
+          "in" : "path",
+          "description" : "The IdShort path to the Operation",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The IdShort path to the Operation",
+            "nullable" : true
+          }
+        }, {
+          "name" : "async",
+          "in" : "query",
+          "description" : "Determines whether the execution of the operation is asynchronous (true) or not (false)",
+          "schema" : {
+            "type" : "boolean",
+            "description" : "Determines whether the execution of the operation is asynchronous (true) or not (false)"
+          }
+        } ],
+        "requestBody" : {
+          "description" : "The parameterized request object for the invocation",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/InvocationRequest"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Operation invoked successfully"
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Submodel / Method handler not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/aas/submodels/{submodelIdShort}/submodel/submodelElements/{idShortPathToOperation}/invocationList/{requestId}" : {
+      "get" : {
+        "tags" : [ "AssetAdministrationShell" ],
+        "summary" : "Retrieves the result of an asynchronously started operation",
+        "operationId" : "Shell_GetInvocationResultByIdShort",
+        "parameters" : [ {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "Submodel's short id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "idShortPathToOperation",
+          "in" : "path",
+          "description" : "The IdShort path to the Operation",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The IdShort path to the Operation",
+            "nullable" : true
+          }
+        }, {
+          "name" : "requestId",
+          "in" : "path",
+          "description" : "The request id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The request id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Result found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/InvocationResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Submodel / Operation / Request not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "KeyType" : {
+        "enum" : [ "Undefined", "Custom", "IRI", "URI", "IRDI", "IdShort", "FragmentId" ],
+        "type" : "string"
+      },
+      "Identifier" : {
+        "required" : [ "id", "idType" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "idType" : {
+            "$ref" : "#/components/schemas/KeyType"
+          }
+        }
+      },
+      "AdministrativeInformation" : {
+        "type" : "object",
+        "properties" : {
+          "version" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "revision" : {
+            "type" : "string",
+            "nullable" : true
+          }
+        }
+      },
+      "LangString" : {
+        "type" : "object",
+        "properties" : {
+          "language" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "text" : {
+            "type" : "string",
+            "nullable" : true
+          }
+        }
+      },
+      "IEndpointSecurity" : {
+        "type" : "object"
+      },
+      "IEndpoint" : {
+        "type" : "object",
+        "properties" : {
+          "address" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "type" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "security" : {
+            "$ref" : "#/components/schemas/IEndpointSecurity"
+          }
+        }
+      },
+      "ModelType" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          }
+        }
+      },
+      "AssetKind" : {
+        "enum" : [ "Type", "Instance" ],
+        "type" : "string"
+      },
+      "KeyElements" : {
+        "enum" : [ "Undefined", "GlobalReference", "FragmentReference", "AccessPermissionRule", "AnnotatedRelationshipElement", "BasicEvent", "Blob", "Capability", "ConceptDictionary", "DataElement", "File", "Entity", "Event", "MultiLanguageProperty", "Operation", "Property", "Range", "ReferenceElement", "RelationshipElement", "SubmodelElement", "SubmodelElementCollection", "View", "Asset", "AssetAdministrationShell", "ConceptDescription", "Submodel" ],
+        "type" : "string"
+      },
+      "Key" : {
+        "required" : [ "idType", "local", "type", "value" ],
+        "type" : "object",
+        "properties" : {
+          "type" : {
+            "$ref" : "#/components/schemas/KeyElements"
+          },
+          "idType" : {
+            "$ref" : "#/components/schemas/KeyType"
+          },
+          "value" : {
+            "type" : "string"
+          },
+          "local" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "SubmodelReference" : {
+        "type" : "object",
+        "properties" : {
+          "keys" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Key"
+            },
+            "nullable" : true
+          }
+        }
+      },
+      "Reference" : {
+        "type" : "object",
+        "properties" : {
+          "keys" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Key"
+            },
+            "nullable" : true
+          }
+        }
+      },
+      "IDataSpecificationContent" : {
+        "type" : "object"
+      },
+      "IEmbeddedDataSpecification" : {
+        "type" : "object",
+        "properties" : {
+          "hasDataSpecification" : {
+            "$ref" : "#/components/schemas/Reference"
+          },
+          "dataSpecificationContent" : {
+            "$ref" : "#/components/schemas/IDataSpecificationContent"
+          }
+        }
+      },
+      "Asset" : {
+        "type" : "object",
+        "properties" : {
+          "idShort" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "kind" : {
+            "$ref" : "#/components/schemas/AssetKind"
+          },
+          "assetIdentificationModel" : {
+            "$ref" : "#/components/schemas/SubmodelReference"
+          },
+          "billOfMaterial" : {
+            "$ref" : "#/components/schemas/SubmodelReference"
+          },
+          "embeddedDataSpecifications" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/IEmbeddedDataSpecification"
+            },
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "modelType" : {
+            "$ref" : "#/components/schemas/ModelType"
+          },
+          "identification" : {
+            "$ref" : "#/components/schemas/Identifier"
+          },
+          "administration" : {
+            "$ref" : "#/components/schemas/AdministrativeInformation"
+          },
+          "category" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "description" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/LangString"
+            },
+            "nullable" : true
+          }
+        }
+      },
+      "SubmodelDescriptor" : {
+        "type" : "object",
+        "properties" : {
+          "idShort" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "identification" : {
+            "$ref" : "#/components/schemas/Identifier"
+          },
+          "administration" : {
+            "$ref" : "#/components/schemas/AdministrativeInformation"
+          },
+          "description" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/LangString"
+            },
+            "nullable" : true
+          },
+          "semanticId" : {
+            "$ref" : "#/components/schemas/Reference"
+          },
+          "endpoints" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/IEndpoint"
+            },
+            "nullable" : true
+          },
+          "category" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "modelType" : {
+            "$ref" : "#/components/schemas/ModelType"
+          }
+        }
+      },
+      "AssetAdministrationShellDescriptor" : {
+        "type" : "object",
+        "properties" : {
+          "idShort" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "identification" : {
+            "$ref" : "#/components/schemas/Identifier"
+          },
+          "administration" : {
+            "$ref" : "#/components/schemas/AdministrativeInformation"
+          },
+          "description" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/LangString"
+            },
+            "nullable" : true
+          },
+          "endpoints" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/IEndpoint"
+            },
+            "nullable" : true
+          },
+          "category" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "modelType" : {
+            "$ref" : "#/components/schemas/ModelType"
+          },
+          "asset" : {
+            "$ref" : "#/components/schemas/Asset"
+          },
+          "submodels" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SubmodelDescriptor"
+            },
+            "nullable" : true
+          }
+        }
+      },
+      "ModelingKind" : {
+        "enum" : [ "Instance", "Template" ],
+        "type" : "string"
+      },
+      "IConstraint" : {
+        "type" : "object",
+        "properties" : {
+          "modelType" : {
+            "$ref" : "#/components/schemas/ModelType"
+          }
+        }
+      },
+      "ISubmodelElement" : {
+        "type" : "object",
+        "properties" : {
+          "idShort" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "semanticId" : {
+            "$ref" : "#/components/schemas/Reference"
+          },
+          "constraints" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/IConstraint"
+            },
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "description" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/LangString"
+            },
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "category" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "kind" : {
+            "$ref" : "#/components/schemas/ModelingKind"
+          },
+          "modelType" : {
+            "$ref" : "#/components/schemas/ModelType"
+          },
+          "embeddedDataSpecifications" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/IEmbeddedDataSpecification"
+            },
+            "nullable" : true,
+            "readOnly" : true
+          }
+        }
+      },
+      "Submodel" : {
+        "type" : "object",
+        "properties" : {
+          "idShort" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "kind" : {
+            "$ref" : "#/components/schemas/ModelingKind"
+          },
+          "semanticId" : {
+            "$ref" : "#/components/schemas/Reference"
+          },
+          "submodelElements" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ISubmodelElement"
+            },
+            "nullable" : true
+          },
+          "modelType" : {
+            "$ref" : "#/components/schemas/ModelType"
+          },
+          "embeddedDataSpecifications" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/IEmbeddedDataSpecification"
+            },
+            "nullable" : true
+          },
+          "qualifiers" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/IConstraint"
+            },
+            "nullable" : true
+          },
+          "identification" : {
+            "$ref" : "#/components/schemas/Identifier"
+          },
+          "administration" : {
+            "$ref" : "#/components/schemas/AdministrativeInformation"
+          },
+          "category" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "description" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/LangString"
+            },
+            "nullable" : true
+          }
+        }
+      },
+      "MessageType" : {
+        "enum" : [ "Unspecified", "Debug", "Information", "Warning", "Error", "Fatal", "Exception" ],
+        "type" : "string"
+      },
+      "Message" : {
+        "type" : "object",
+        "properties" : {
+          "messageType" : {
+            "$ref" : "#/components/schemas/MessageType"
+          },
+          "text" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "code" : {
+            "type" : "string",
+            "nullable" : true
+          }
+        }
+      },
+      "Result" : {
+        "type" : "object",
+        "properties" : {
+          "success" : {
+            "type" : "boolean"
+          },
+          "isException" : {
+            "type" : "boolean",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "entity" : {
+            "type" : "object",
+            "nullable" : true
+          },
+          "entityType" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "messages" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Message"
+            },
+            "nullable" : true
+          }
+        }
+      },
+      "SubmodelElement" : {
+        "type" : "object",
+        "properties" : {
+          "idShort" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "semanticId" : {
+            "$ref" : "#/components/schemas/Reference"
+          },
+          "qualifiers" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/IConstraint"
+            },
+            "nullable" : true
+          },
+          "kind" : {
+            "$ref" : "#/components/schemas/ModelingKind"
+          },
+          "modelType" : {
+            "$ref" : "#/components/schemas/ModelType"
+          },
+          "embeddedDataSpecifications" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/IEmbeddedDataSpecification"
+            },
+            "nullable" : true
+          },
+          "category" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "description" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/LangString"
+            },
+            "nullable" : true
+          }
+        }
+      },
+      "ElementValue" : {
+        "type" : "object",
+        "properties" : {
+          "value" : {
+            "type" : "object",
+            "nullable" : true
+          }
+        }
+      },
+      "OperationVariable" : {
+        "type" : "object",
+        "properties" : {
+          "modelType" : {
+            "$ref" : "#/components/schemas/ModelType"
+          },
+          "value" : {
+            "$ref" : "#/components/schemas/ISubmodelElement"
+          }
+        }
+      },
+      "InvocationRequest" : {
+        "type" : "object",
+        "properties" : {
+          "requestId" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "inputArguments" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/OperationVariable"
+            },
+            "nullable" : true
+          },
+          "inoutputArguments" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/OperationVariable"
+            },
+            "nullable" : true
+          },
+          "timeout" : {
+            "type" : "integer",
+            "format" : "int32",
+            "nullable" : true
+          }
+        }
+      },
+      "OperationResult" : {
+        "type" : "object",
+        "properties" : {
+          "success" : {
+            "type" : "boolean"
+          },
+          "isException" : {
+            "type" : "boolean",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "entity" : {
+            "type" : "object",
+            "nullable" : true
+          },
+          "entityType" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "messages" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Message"
+            },
+            "nullable" : true
+          }
+        }
+      },
+      "ExecutionState" : {
+        "enum" : [ "Initiated", "Running", "Completed", "Canceled", "Failed", "Timeout" ],
+        "type" : "string"
+      },
+      "InvocationResponse" : {
+        "type" : "object",
+        "properties" : {
+          "requestId" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "inoutputArguments" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/OperationVariable"
+            },
+            "nullable" : true
+          },
+          "outputArguments" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/OperationVariable"
+            },
+            "nullable" : true
+          },
+          "operationResult" : {
+            "$ref" : "#/components/schemas/OperationResult"
+          },
+          "executionState" : {
+            "$ref" : "#/components/schemas/ExecutionState"
+          }
+        }
+      },
+      "AssetAdministrationShellReference" : {
+        "type" : "object",
+        "properties" : {
+          "keys" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Key"
+            },
+            "nullable" : true
+          }
+        }
+      },
+      "View" : {
+        "type" : "object",
+        "properties" : {
+          "idShort" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "containedElements" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Reference"
+            },
+            "nullable" : true
+          },
+          "semanticId" : {
+            "$ref" : "#/components/schemas/Reference"
+          },
+          "category" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "description" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/LangString"
+            },
+            "nullable" : true
+          },
+          "modelType" : {
+            "$ref" : "#/components/schemas/ModelType"
+          }
+        }
+      },
+      "ConceptDescriptionReference" : {
+        "type" : "object",
+        "properties" : {
+          "keys" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Key"
+            },
+            "nullable" : true
+          }
+        }
+      },
+      "ConceptDictionary" : {
+        "type" : "object",
+        "properties" : {
+          "idShort" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "category" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "description" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/LangString"
+            },
+            "nullable" : true
+          },
+          "metaData" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            },
+            "nullable" : true
+          },
+          "conceptDescriptions" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ConceptDescriptionReference"
+            },
+            "nullable" : true
+          },
+          "modelType" : {
+            "$ref" : "#/components/schemas/ModelType"
+          }
+        }
+      },
+      "AssetAdministrationShell" : {
+        "type" : "object",
+        "properties" : {
+          "idShort" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "asset" : {
+            "$ref" : "#/components/schemas/Asset"
+          },
+          "submodels" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Submodel"
+            },
+            "nullable" : true
+          },
+          "derivedFrom" : {
+            "$ref" : "#/components/schemas/AssetAdministrationShellReference"
+          },
+          "views" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/View"
+            },
+            "nullable" : true
+          },
+          "modelType" : {
+            "$ref" : "#/components/schemas/ModelType"
+          },
+          "embeddedDataSpecifications" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/IEmbeddedDataSpecification"
+            },
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "conceptDictionaries" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ConceptDictionary"
+            },
+            "nullable" : true
+          },
+          "identification" : {
+            "$ref" : "#/components/schemas/Identifier"
+          },
+          "administration" : {
+            "$ref" : "#/components/schemas/AdministrativeInformation"
+          },
+          "category" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "description" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/LangString"
+            },
+            "nullable" : true
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/source/content/user_documentation/developer/basyx_java_v1/swagger/basyx_asset_administration_shell_repository_http_rest_api-v1.json
+++ b/docs/source/content/user_documentation/developer/basyx_java_v1/swagger/basyx_asset_administration_shell_repository_http_rest_api-v1.json
@@ -1,0 +1,1011 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "BaSyx Asset Administration Shell Repository HTTP REST-API",
+    "description" : "The full description of the generic BaSyx Asset Administration Shell Repository HTTP REST-API",
+    "contact" : {
+      "name" : "Constantin Ziesche",
+      "url" : "https://www.bosch.com/de/",
+      "email" : "constantin.ziesche@bosch.com"
+    },
+    "license" : {
+      "name" : "EPL-2.0",
+      "url" : "https://www.eclipse.org/legal/epl-2.0/"
+    },
+    "version" : "v1"
+  },
+  "paths" : {
+    "/shells" : {
+      "get" : {
+        "tags" : [ "AssetAdministrationShellRepository" ],
+        "summary" : "Retrieves all Asset Administration Shells from the Asset Administration Shell repository",
+        "operationId" : "GetAllAssetAdministrationShells",
+        "responses" : {
+          "200" : {
+            "description" : "Returns a list of found Asset Administration Shells",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/AssetAdministrationShell"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/shells/{aasId}" : {
+      "get" : {
+        "tags" : [ "AssetAdministrationShellRepository" ],
+        "summary" : "Retrieves a specific Asset Administration Shell from the Asset Administration Shell repository",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Returns the requested Asset Administration Shell",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/AssetAdministrationShell"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "No Asset Administration Shell found"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "AssetAdministrationShellRepository" ],
+        "summary" : "Creates or updates a Asset Administration Shell at the Asset Administration Shell repository",
+        "operationId" : "PutAssetAdministrationShell",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        } ],
+        "requestBody" : {
+          "description" : "The Asset Administration Shell",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/AssetAdministrationShell"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "201" : {
+            "description" : "Asset Administration Shell created successfully",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/AssetAdministrationShell"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "AssetAdministrationShellRepository" ],
+        "summary" : "Deletes a specific Asset Administration Shell at the Asset Administration Shell repository",
+        "operationId" : "DeleteAssetAdministrationShellById",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Asset Administration Shell deleted successfully",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/shells/{aasId}/aas" : {
+      "get" : {
+        "tags" : [ "AssetAdministrationShellRepository" ],
+        "summary" : "Retrieves a specific Asset Administration Shell from the Asset Administration Shell repository",
+        "operationId" : "GetAssetAdministrationShellById",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Returns the requested Asset Administration Shell",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/AssetAdministrationShell"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "No Asset Administration Shell found"
+          }
+        }
+      }
+    },
+    "/shells/{aasId}/aas/submodels" : {
+      "get" : {
+        "tags" : [ "AssetAdministrationShellRepository" ],
+        "summary" : "Retrieves all Submodels from the  Asset Administration Shell",
+        "operationId" : "ShellRepo_GetSubmodelsFromShell",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Returns a list of found Submodels",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "No Submodel Service Providers found"
+          }
+        }
+      }
+    },
+    "/shells/{aasId}/aas/submodels/{submodelIdShort}" : {
+      "put" : {
+        "tags" : [ "AssetAdministrationShellRepository" ],
+        "summary" : "Creates or updates a Submodel to an existing Asset Administration Shell",
+        "operationId" : "ShellRepo_PutSubmodelToShell",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "The Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's short id",
+            "nullable" : true
+          }
+        } ],
+        "requestBody" : {
+          "description" : "The serialized Submodel object",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Submodel"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "201" : {
+            "description" : "Submodel created successfully",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Submodel"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get" : {
+        "tags" : [ "AssetAdministrationShellRepository" ],
+        "summary" : "Retrieves the Submodel from the Asset Administration Shell",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "The Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's short id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Submodel retrieved successfully",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Submodel"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "No Submodel Service Provider found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "AssetAdministrationShellRepository" ],
+        "summary" : "Deletes a specific Submodel from the Asset Administration Shell",
+        "operationId" : "ShellRepo_DeleteSubmodelFromShellByIdShort",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "The Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's short id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "Submodel deleted successfully"
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/shells/{aasId}/aas/submodels/{submodelIdShort}/submodel" : {
+      "get" : {
+        "tags" : [ "AssetAdministrationShellRepository" ],
+        "summary" : "Retrieves the Submodel from the Asset Administration Shell",
+        "operationId" : "ShellRepo_GetSubmodelFromShellByIdShort",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "The Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's short id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Submodel retrieved successfully",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Submodel"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "No Submodel Service Provider found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/shells/{aasId}/aas/submodels/{submodelIdShort}/submodel/values" : {
+      "get" : {
+        "tags" : [ "AssetAdministrationShellRepository" ],
+        "summary" : "Retrieves the minimized version of a Submodel, i.e. only the values of SubmodelElements are serialized and returned",
+        "operationId" : "ShellRepo_GetSubmodelValues",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "The Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's short id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Success"
+          },
+          "404" : {
+            "description" : "Submodel not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/shells/{aasId}/aas/submodels/{submodelIdShort}/submodel/submodelElements" : {
+      "get" : {
+        "tags" : [ "AssetAdministrationShellRepository" ],
+        "summary" : "Retrieves all Submodel-Elements from the Submodel",
+        "operationId" : "ShellRepo_GetSubmodelElements",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "The Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's short id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Returns a list of found Submodel-Elements",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/SubmodelElement"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Submodel not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/shells/{aasId}/aas/submodels/{submodelIdShort}/submodel/submodelElements/{seIdShortPath}" : {
+      "put" : {
+        "tags" : [ "AssetAdministrationShellRepository" ],
+        "summary" : "Creates or updates a Submodel-Element at the Submodel",
+        "operationId" : "ShellRepo_PutSubmodelElement",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "The Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's short id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "seIdShortPath",
+          "in" : "path",
+          "description" : "The Submodel-Element's IdShort-Path",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel-Element's IdShort-Path",
+            "nullable" : true
+          }
+        } ],
+        "requestBody" : {
+          "description" : "The Submodel-Element object",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/SubmodelElement"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "201" : {
+            "description" : "Submodel-Element created successfully",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/SubmodelElement"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Submodel not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get" : {
+        "tags" : [ "AssetAdministrationShellRepository" ],
+        "summary" : "Retrieves a specific Submodel-Element from the Submodel",
+        "operationId" : "ShellRepo_GetSubmodelElementByIdShort",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "The Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's short id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "seIdShortPath",
+          "in" : "path",
+          "description" : "The Submodel-Element's IdShort-Path",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel-Element's IdShort-Path",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Returns the requested Submodel-Element",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/SubmodelElement"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Submodel / Submodel-Element not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "AssetAdministrationShellRepository" ],
+        "summary" : "Deletes a specific Submodel-Element from the Submodel",
+        "operationId" : "ShellRepo_DeleteSubmodelElementByIdShort",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "The Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's short id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "seIdShortPath",
+          "in" : "path",
+          "description" : "The Submodel-Element's IdShort-Path",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel-Element's IdShort-Path",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Success",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "204" : {
+            "description" : "Submodel-Element deleted successfully"
+          },
+          "404" : {
+            "description" : "Submodel / Submodel-Element not found"
+          }
+        }
+      }
+    },
+    "/shells/{aasId}/aas/submodels/{submodelIdShort}/submodel/submodelElements/{seIdShortPath}/value" : {
+      "get" : {
+        "tags" : [ "AssetAdministrationShellRepository" ],
+        "summary" : "Retrieves the value of a specific Submodel-Element from the Submodel",
+        "operationId" : "ShellRepo_GetSubmodelElementValueByIdShort",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "The Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's short id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "seIdShortPath",
+          "in" : "path",
+          "description" : "The Submodel-Element's IdShort-Path",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel-Element's IdShort-Path",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Returns the value of a specific Submodel-Element",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Submodel / Submodel-Element not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "405" : {
+            "description" : "Method not allowed",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "AssetAdministrationShellRepository" ],
+        "summary" : "Updates the Submodel-Element's value",
+        "operationId" : "ShellRepo_PutSubmodelElementValueByIdShort",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "The Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's short id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "seIdShortPath",
+          "in" : "path",
+          "description" : "The Submodel-Element's IdShort-Path",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel-Element's IdShort-Path",
+            "nullable" : true
+          }
+        } ],
+        "requestBody" : {
+          "description" : "The new value",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "object",
+                "description" : "The new value",
+                "nullable" : true
+              }
+            }
+          }
+        },
+        "responses" : {
+          "204" : {
+            "description" : "Submodel-Element's value changed successfully"
+          },
+          "404" : {
+            "description" : "Submodel / Submodel-Element not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "405" : {
+            "description" : "Method not allowed"
+          }
+        }
+      }
+    },
+    "/shells/{aasId}/aas/submodels/{submodelIdShort}/submodel/submodelElements/{idShortPathToOperation}/invoke" : {
+      "post" : {
+        "tags" : [ "AssetAdministrationShellRepository" ],
+        "summary" : "Invokes a specific operation from the Submodel synchronously or asynchronously",
+        "operationId" : "ShellRepo_InvokeOperationByIdShort",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "Submodel's short id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "idShortPathToOperation",
+          "in" : "path",
+          "description" : "The IdShort path to the Operation",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The IdShort path to the Operation",
+            "nullable" : true
+          }
+        }, {
+          "name" : "async",
+          "in" : "query",
+          "description" : "Determines whether the execution of the operation is asynchronous (true) or not (false)",
+          "schema" : {
+            "type" : "boolean",
+            "description" : "Determines whether the execution of the operation is asynchronous (true) or not (false)"
+          }
+        } ],
+        "requestBody" : {
+          "description" : "The parameterized request object for the invocation",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/InvocationRequest"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Operation invoked successfully"
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Submodel / Method handler not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/shells/{aasId}/aas/submodels/{submodelIdShort}/submodel/submodelElements/{idShortPathToOperation}/invocationList/{requestId}" : {
+      "get" : {
+        "tags" : [ "AssetAdministrationShellRepository" ],
+        "summary" : "Retrieves the result of an asynchronously started operation",
+        "operationId" : "ShellRepo_GetInvocationResultByIdShort",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "submodelIdShort",
+          "in" : "path",
+          "description" : "Submodel's short id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "Submodel's short id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "idShortPathToOperation",
+          "in" : "path",
+          "description" : "The IdShort path to the Operation",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The IdShort path to the Operation",
+            "nullable" : true
+          }
+        }, {
+          "name" : "requestId",
+          "in" : "path",
+          "description" : "The request id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The request id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Result found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/InvocationResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Submodel / Operation / Request not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/source/content/user_documentation/developer/basyx_java_v1/swagger/basyx_registry_api-v1.json
+++ b/docs/source/content/user_documentation/developer/basyx_java_v1/swagger/basyx_registry_api-v1.json
@@ -1,0 +1,450 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "BaSyx Registry HTTP REST-API",
+    "description" : "The full OpenAPI 3.0.1 specification of the BaSyx Registry HTTP REST-API",
+    "contact" : {
+      "name" : "Constantin Ziesche",
+      "url" : "https://www.bosch.com/de/",
+      "email" : "constantin.ziesche@bosch.com"
+    },
+    "license" : {
+      "name" : "EPL-2.0",
+      "url" : "https://www.eclipse.org/legal/epl-2.0/"
+    },
+    "version" : "v1"
+  },
+  "servers" : [ {
+    "url" : "http://{authority}/",
+    "description" : "This is the unsecure server to access the BaSyx Registry",
+    "variables" : {
+      "authority" : {
+        "default" : "localhost:4999",
+        "description" : "The authority is the server url (made of IP-Address or DNS-Name, user information, and/or port information) of the hosting environment for the BaSyx Registry"
+      }
+    }
+  }, {
+    "url" : "https://{authority}/",
+    "description" : "This is the secure server to access the BaSyx Registry",
+    "variables" : {
+      "authority" : {
+        "default" : "localhost:4999",
+        "description" : "The authority is the server url (made of IP-Address or DNS-Name, user information, and/or port information) of the hosting environment for the BaSyx Registry"
+      }
+    }
+  } ],
+  "paths" : {
+    "/api/v1/registry" : {
+      "get" : {
+        "tags" : [ "AssetAdministrationShellRegistry" ],
+        "summary" : "Retrieves all registered Asset Administration Shells within system (e.g. Station, Line, Plant, Area, etc.) defined by the Registry",
+        "operationId" : "GetAllAssetAdministrationShellDescriptors",
+        "responses" : {
+          "200" : {
+            "description" : "Returns a list of found Asset Administration Shell Descriptors",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/AssetAdministrationShellDescriptor"
+                  }
+                }
+              }
+            }
+          },
+          "default" : {
+            "description" : "Unexpected error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/{aasId}" : {
+      "get" : {
+        "tags" : [ "AssetAdministrationShellRegistry" ],
+        "summary" : "Retrieves a specific Asset Administration Shell registration",
+        "operationId" : "GetAssetAdministrationShellDescriptor",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Returns the requested Asset Administration Shell",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/AssetAdministrationShellDescriptor"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "description" : "No Asset Administration Shell with passed id found"
+          },
+          "default" : {
+            "description" : "Unexpected error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "AssetAdministrationShellRegistry" ],
+        "summary" : "Creates a new or updates an existing Asset Administration Shell registration at the Registry",
+        "operationId" : "RegisterAssetAdministrationShell",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        } ],
+        "requestBody" : {
+          "description" : "The Asset Administration Shell Descriptor",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/AssetAdministrationShellDescriptor"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "The Asset Administration Shell's registration was successfully renewed"
+          },
+          "204" : {
+            "description" : "Success",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "The syntax of the passed Asset Administration Shell is not valid or malformed request"
+          },
+          "404" : {
+            "description" : "No Asset Administration Shell with passed id found"
+          },
+          "default" : {
+            "description" : "Unexpected error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "AssetAdministrationShellRegistry" ],
+        "summary" : "Deletes the Asset Administration Shell registration from the Registry",
+        "operationId" : "UnregisterAssetAdministrationShell",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The Asset Administration Shell was deleted successfully"
+          },
+          "204" : {
+            "description" : "Success",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "description" : "No Asset Administration Shell with passed id found"
+          },
+          "default" : {
+            "description" : "Unexpected error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/{aasId}/submodels/{submodelId}" : {
+      "put" : {
+        "tags" : [ "AssetAdministrationShellRegistry" ],
+        "summary" : "Creates a new or updates an existing Submodel registration at a specific Asset Administration Shell registered at the Registry",
+        "operationId" : "RegisterSubmodelAtAssetAdministrationShell",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "submodelId",
+          "in" : "path",
+          "description" : "The Submodel's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's unique id",
+            "nullable" : true
+          }
+        } ],
+        "requestBody" : {
+          "description" : "The Submodel Descriptor",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/SubmodelDescriptor"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "201" : {
+            "description" : "The Submodel was created successfully",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/SubmodelDescriptor"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "The syntax of the passed Submodel is not valid or malformed request"
+          },
+          "404" : {
+            "description" : "No Asset Administration Shell with passed id found"
+          },
+          "default" : {
+            "description" : "Unexpected error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get" : {
+        "tags" : [ "AssetAdministrationShellRegistry" ],
+        "summary" : "Retrieves the Submodel registration from a specific Asset Administration Shell registered at the Registry",
+        "operationId" : "GetSubmodelDescriptorFromAssetAdministrationShell",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "submodelId",
+          "in" : "path",
+          "description" : "The Submodel's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's unique id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Returns the requested Submodels Descriptor",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/SubmodelDescriptor"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "description" : "No Asset Administration Shell / Submodel with passed id found"
+          },
+          "default" : {
+            "description" : "Unexpected error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "AssetAdministrationShellRegistry" ],
+        "summary" : "Unregisters the Submodel from a specific Asset Administration Shell registered at the Registry",
+        "operationId" : "DeleteSubmodelDescriptorFromAssetAdministrationShell",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "submodelId",
+          "in" : "path",
+          "description" : "The Submodel's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's unique id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "The Submodel Descriptor was successfully unregistered"
+          },
+          "204" : {
+            "description" : "Success",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "description" : "No Asset Administration Shell / Submodel with passed id found"
+          },
+          "default" : {
+            "description" : "Unexpected error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/registry/{aasId}/submodels" : {
+      "get" : {
+        "tags" : [ "AssetAdministrationShellRegistry" ],
+        "summary" : "Retrieves all Submodel registrations from a specific Asset Administration Shell registered at the Registry",
+        "operationId" : "GetAllSubmodelDescriptorsFromAssetAdministrationShell",
+        "parameters" : [ {
+          "name" : "aasId",
+          "in" : "path",
+          "description" : "The Asset Administration Shell's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Asset Administration Shell's unique id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Returns a list of found Submodels Descriptors",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/SubmodelDescriptor"
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          },
+          "404" : {
+            "description" : "No Asset Administration Shell with passed id found"
+          },
+          "default" : {
+            "description" : "Unexpected error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "tags" : [ {
+    "name" : "AssetAdministrationShellRegistry",
+    "description" : "The Http-Controller implementation of the IAssetAdministrationShellRegistry interface"
+  } ]
+}

--- a/docs/source/content/user_documentation/developer/basyx_java_v1/swagger/basyx_submodel_http_rest_api-v1.json
+++ b/docs/source/content/user_documentation/developer/basyx_java_v1/swagger/basyx_submodel_http_rest_api-v1.json
@@ -1,0 +1,458 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "BaSyx Submodel HTTP REST-API",
+    "description" : "The full description of the generic BaSyx Submodel HTTP REST-API",
+    "contact" : {
+      "name" : "Constantin Ziesche",
+      "url" : "https://www.bosch.com/de/",
+      "email" : "constantin.ziesche@bosch.com"
+    },
+    "license" : {
+      "name" : "EPL-2.0",
+      "url" : "https://www.eclipse.org/legal/epl-2.0/"
+    },
+    "version" : "v1"
+  },
+  "paths" : {
+    "/submodel" : {
+      "get" : {
+        "tags" : [ "Submodel" ],
+        "summary" : "Retrieves the entire Submodel",
+        "operationId" : "GetSubmodel",
+        "responses" : {
+          "200" : {
+            "description" : "Success",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Submodel"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Submodel not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/submodel/values" : {
+      "get" : {
+        "tags" : [ "Submodel" ],
+        "summary" : "Retrieves the minimized version of a Submodel, i.e. only the values of SubmodelElements are serialized and returned",
+        "operationId" : "GetSubmodelValues",
+        "responses" : {
+          "200" : {
+            "description" : "Success"
+          },
+          "404" : {
+            "description" : "Submodel not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/submodel/submodelElements" : {
+      "get" : {
+        "tags" : [ "Submodel" ],
+        "summary" : "Retrieves all Submodel-Elements from the Submodel",
+        "operationId" : "GetSubmodelElements",
+        "responses" : {
+          "200" : {
+            "description" : "Returns a list of found Submodel-Elements",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/SubmodelElement"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Submodel not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/submodel/submodelElements/{seIdShortPath}" : {
+      "put" : {
+        "tags" : [ "Submodel" ],
+        "summary" : "Creates or updates a Submodel-Element at the Submodel",
+        "operationId" : "PutSubmodelElement",
+        "parameters" : [ {
+          "name" : "seIdShortPath",
+          "in" : "path",
+          "description" : "The Submodel-Element's IdShort-Path",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel-Element's IdShort-Path",
+            "nullable" : true
+          }
+        } ],
+        "requestBody" : {
+          "description" : "The Submodel-Element object",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/SubmodelElement"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "201" : {
+            "description" : "Submodel-Element created successfully",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/SubmodelElement"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get" : {
+        "tags" : [ "Submodel" ],
+        "summary" : "Retrieves a specific Submodel-Element from the Submodel",
+        "operationId" : "GetSubmodelElementByIdShort",
+        "parameters" : [ {
+          "name" : "seIdShortPath",
+          "in" : "path",
+          "description" : "The Submodel-Element's IdShort-Path",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel-Element's IdShort-Path",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Returns the requested Submodel-Element",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/SubmodelElement"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Submodel Element not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "Submodel" ],
+        "summary" : "Deletes a specific Submodel-Element from the Submodel",
+        "operationId" : "DeleteSubmodelElementByIdShort",
+        "parameters" : [ {
+          "name" : "seIdShortPath",
+          "in" : "path",
+          "description" : "The Submodel-Element's IdShort-Path",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel-Element's IdShort-Path",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Success",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "204" : {
+            "description" : "Submodel-Element deleted successfully"
+          },
+          "404" : {
+            "description" : "Submodel-Element not found"
+          }
+        }
+      }
+    },
+    "/submodel/submodelElements/{seIdShortPath}/value" : {
+      "get" : {
+        "tags" : [ "Submodel" ],
+        "summary" : "Retrieves the value of a specific Submodel-Element from the Submodel",
+        "operationId" : "GetSubmodelElementValueByIdShort",
+        "parameters" : [ {
+          "name" : "seIdShortPath",
+          "in" : "path",
+          "description" : "The Submodel-Element's IdShort-Path",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel-Element's IdShort-Path",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Returns the value of a specific Submodel-Element",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Submodel / Submodel-Element not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "405" : {
+            "description" : "Method not allowed",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "Submodel" ],
+        "summary" : "Updates the Submodel-Element's value",
+        "operationId" : "PutSubmodelElementValueByIdShort",
+        "parameters" : [ {
+          "name" : "seIdShortPath",
+          "in" : "path",
+          "description" : "The Submodel-Element's IdShort-Path",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel-Element's IdShort-Path",
+            "nullable" : true
+          }
+        } ],
+        "requestBody" : {
+          "description" : "The new value",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "object",
+                "description" : "The new value",
+                "nullable" : true
+              }
+            }
+          }
+        },
+        "responses" : {
+          "204" : {
+            "description" : "Submodel-Element's value changed successfully"
+          },
+          "404" : {
+            "description" : "Submodel-Element not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "405" : {
+            "description" : "Method not allowed"
+          }
+        }
+      }
+    },
+    "/submodel/submodelElements/{idShortPathToOperation}/invoke" : {
+      "post" : {
+        "tags" : [ "Submodel" ],
+        "summary" : "Invokes a specific operation from the Submodel synchronously or asynchronously",
+        "operationId" : "InvokeOperationByIdShort",
+        "parameters" : [ {
+          "name" : "idShortPathToOperation",
+          "in" : "path",
+          "description" : "The IdShort path to the Operation",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The IdShort path to the Operation",
+            "nullable" : true
+          }
+        }, {
+          "name" : "async",
+          "in" : "query",
+          "description" : "Determines whether the execution of the operation is asynchronous (true) or not (false)",
+          "schema" : {
+            "type" : "boolean",
+            "description" : "Determines whether the execution of the operation is asynchronous (true) or not (false)"
+          }
+        } ],
+        "requestBody" : {
+          "description" : "The parameterized request object for the invocation",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/InvocationRequest"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Operation invoked successfully",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/InvocationResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Method handler not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/submodel/submodelElements/{idShortPathToOperation}/invocationList/{requestId}" : {
+      "get" : {
+        "tags" : [ "Submodel" ],
+        "summary" : "Retrieves the result of an asynchronously started operation",
+        "operationId" : "GetInvocationResultByIdShort",
+        "parameters" : [ {
+          "name" : "idShortPathToOperation",
+          "in" : "path",
+          "description" : "The IdShort path to the Operation",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The IdShort path to the Operation",
+            "nullable" : true
+          }
+        }, {
+          "name" : "requestId",
+          "in" : "path",
+          "description" : "The request id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The request id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Result found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/InvocationResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Operation / Request not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "https://api.swaggerhub.com/domains/BaSyx/SharedModels/v1#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/source/content/user_documentation/developer/basyx_java_v1/swagger/basyx_submodel_repository_http_rest_api-v1.json
+++ b/docs/source/content/user_documentation/developer/basyx_java_v1/swagger/basyx_submodel_repository_http_rest_api-v1.json
@@ -1,0 +1,1425 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "BaSyx Submodel Repository HTTP REST-API",
+    "description" : "The full description of the generic BaSyx Submodel Repository HTTP REST-API",
+    "contact" : {
+      "name" : "Constantin Ziesche",
+      "url" : "https://www.bosch.com/de/",
+      "email" : "constantin.ziesche@bosch.com"
+    },
+    "license" : {
+      "name" : "EPL-2.0",
+      "url" : "https://www.eclipse.org/legal/epl-2.0/"
+    },
+    "version" : "v1"
+  },
+  "paths" : {
+    "/submodels" : {
+      "get" : {
+        "tags" : [ "SubmodelRepository" ],
+        "summary" : "Retrieves all Submodels from the Submodel repository",
+        "operationId" : "GetAllSubmodelsFromRepo",
+        "responses" : {
+          "200" : {
+            "description" : "Returns a list of found Submodels",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/Submodel"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/submodels/{submodelId}" : {
+      "get" : {
+        "tags" : [ "SubmodelRepository" ],
+        "summary" : "Retrieves a specific Submodel from the Submodel repository",
+        "parameters" : [ {
+          "name" : "submodelId",
+          "in" : "path",
+          "description" : "The Submodel's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's unique id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Returns the requested Submodel",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Submodel"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "No Submodel found"
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "SubmodelRepository" ],
+        "summary" : "Creates or updates a Submodel at the Submodel repository",
+        "operationId" : "PutSubmodelToRepo",
+        "parameters" : [ {
+          "name" : "submodelId",
+          "in" : "path",
+          "description" : "The Submodel's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's unique id",
+            "nullable" : true
+          }
+        } ],
+        "requestBody" : {
+          "description" : "The Submodel object",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Submodel"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "201" : {
+            "description" : "Submodel created / updated successfully",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Submodel"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request"
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "SubmodelRepository" ],
+        "summary" : "Deletes a specific Submodel at the Submodel repository",
+        "operationId" : "DeleteSubmodelFromRepoById",
+        "parameters" : [ {
+          "name" : "submodelId",
+          "in" : "path",
+          "description" : "The Submodel's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's unique id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Submodel deleted successfully",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/submodels/{submodelId}/submodel" : {
+      "get" : {
+        "tags" : [ "SubmodelRepository" ],
+        "summary" : "Retrieves a specific Submodel from the Submodel repository",
+        "operationId" : "RetrieveSubmodelFromRepoById",
+        "parameters" : [ {
+          "name" : "submodelId",
+          "in" : "path",
+          "description" : "The Submodel's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's unique id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Returns the requested Submodel",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Submodel"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "No Submodel found"
+          }
+        }
+      }
+    },
+    "/submodels/{submodelId}/submodel/values" : {
+      "get" : {
+        "tags" : [ "SubmodelRepository" ],
+        "summary" : "Retrieves the minimized version of a Submodel, i.e. only the values of SubmodelElements are serialized and returned",
+        "operationId" : "SubmodelRepo_GetSubmodelValues",
+        "parameters" : [ {
+          "name" : "submodelId",
+          "in" : "path",
+          "description" : "The Submodel's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's unique id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Success"
+          },
+          "404" : {
+            "description" : "Submodel not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/submodels/{submodelId}/submodel/submodelElements" : {
+      "get" : {
+        "tags" : [ "SubmodelRepository" ],
+        "summary" : "Retrieves all Submodel-Elements from the Submodel",
+        "operationId" : "SubmodelRepo_GetSubmodelElements",
+        "parameters" : [ {
+          "name" : "submodelId",
+          "in" : "path",
+          "description" : "The Submodel's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's unique id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Returns a list of found Submodel-Elements",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/SubmodelElement"
+                  }
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Submodel not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/submodels/{submodelId}/submodel/submodelElements/{seIdShortPath}" : {
+      "put" : {
+        "tags" : [ "SubmodelRepository" ],
+        "summary" : "Creates or updates a Submodel-Element at the Submodel",
+        "operationId" : "SubmodelRepo_PutSubmodelElement",
+        "parameters" : [ {
+          "name" : "submodelId",
+          "in" : "path",
+          "description" : "The Submodel's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's unique id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "seIdShortPath",
+          "in" : "path",
+          "description" : "The Submodel-Element's IdShort-Path",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel-Element's IdShort-Path",
+            "nullable" : true
+          }
+        } ],
+        "requestBody" : {
+          "description" : "The Submodel-Element object",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ISubmodelElement"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "201" : {
+            "description" : "Submodel-Element created successfully",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SubmodelElement"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Submodel not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get" : {
+        "tags" : [ "SubmodelRepository" ],
+        "summary" : "Retrieves a specific Submodel-Element from the Submodel",
+        "operationId" : "SubmodelRepo_GetSubmodelElementById",
+        "parameters" : [ {
+          "name" : "submodelId",
+          "in" : "path",
+          "description" : "The Submodel's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's unique id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "seIdShortPath",
+          "in" : "path",
+          "description" : "The Submodel-Element's IdShort-Path",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel-Element's IdShort-Path",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Returns the requested Submodel-Element",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SubmodelElement"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Submodel / Submodel-Element not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete" : {
+        "tags" : [ "SubmodelRepository" ],
+        "summary" : "Deletes a specific Submodel-Element from the Submodel",
+        "operationId" : "SubmodelRepo_DeleteSubmodelElementById",
+        "parameters" : [ {
+          "name" : "submodelId",
+          "in" : "path",
+          "description" : "The Submodel's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's unique id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "seIdShortPath",
+          "in" : "path",
+          "description" : "The Submodel-Element's IdShort-Path",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel-Element's IdShort-Path",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Success",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "204" : {
+            "description" : "Submodel-Element deleted successfully"
+          },
+          "404" : {
+            "description" : "Submodel / Submodel-Element not found"
+          }
+        }
+      }
+    },
+    "/submodels/{submodelId}/submodel/submodelElements/{seIdShortPath}/value" : {
+      "get" : {
+        "tags" : [ "SubmodelRepository" ],
+        "summary" : "Retrieves the value of a specific Submodel-Element from the Submodel",
+        "operationId" : "SubmodelRepo_GetSubmodelElementValueById",
+        "parameters" : [ {
+          "name" : "submodelId",
+          "in" : "path",
+          "description" : "The Submodel's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's unique id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "seIdShortPath",
+          "in" : "path",
+          "description" : "The Submodel-Element's IdShort-Path",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel-Element's IdShort-Path",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Returns the value of a specific Submodel-Element",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "object"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Submodel / Submodel-Element not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "405" : {
+            "description" : "Method not allowed",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put" : {
+        "tags" : [ "SubmodelRepository" ],
+        "summary" : "Updates the Submodel-Element's value",
+        "operationId" : "SubmodelRepo_PutSubmodelElementValueById",
+        "parameters" : [ {
+          "name" : "submodelId",
+          "in" : "path",
+          "description" : "The Submodel's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's unique id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "seIdShortPath",
+          "in" : "path",
+          "description" : "The Submodel-Element's IdShort-Path",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel-Element's IdShort-Path",
+            "nullable" : true
+          }
+        } ],
+        "requestBody" : {
+          "description" : "The new value",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "object",
+                "description" : "The new value",
+                "nullable" : true
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Submodel-Element's value changed successfully",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ElementValue"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Submodel / Submodel-Element not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "405" : {
+            "description" : "Method not allowed"
+          }
+        }
+      }
+    },
+    "/submodels/{submodelId}/submodel/submodelElements/{idShortPathToOperation}/invoke" : {
+      "post" : {
+        "tags" : [ "SubmodelRepository" ],
+        "summary" : "Invokes a specific operation from the Submodel synchronously or asynchronously",
+        "operationId" : "SubmodelRepo_InvokeOperationById",
+        "parameters" : [ {
+          "name" : "submodelId",
+          "in" : "path",
+          "description" : "The Submodel's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's unique id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "idShortPathToOperation",
+          "in" : "path",
+          "description" : "The IdShort path to the Operation",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The IdShort path to the Operation",
+            "nullable" : true
+          }
+        }, {
+          "name" : "async",
+          "in" : "query",
+          "description" : "Determines whether the execution of the operation is asynchronous (true) or not (false)",
+          "schema" : {
+            "type" : "boolean",
+            "description" : "Determines whether the execution of the operation is asynchronous (true) or not (false)"
+          }
+        } ],
+        "requestBody" : {
+          "description" : "The parameterized request object for the invocation",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/InvocationRequest"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Operation invoked successfully"
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Submodel / Method handler not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/submodels/{submodelId}/submodel/submodelElements/{idShortPathToOperation}/invocationList/{requestId}" : {
+      "get" : {
+        "tags" : [ "SubmodelRepository" ],
+        "summary" : "Retrieves the result of an asynchronously started operation",
+        "operationId" : "SubmodelRepo_GetInvocationResultById",
+        "parameters" : [ {
+          "name" : "submodelId",
+          "in" : "path",
+          "description" : "The Submodel's unique id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The Submodel's unique id",
+            "nullable" : true
+          }
+        }, {
+          "name" : "idShortPathToOperation",
+          "in" : "path",
+          "description" : "The IdShort path to the Operation",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The IdShort path to the Operation",
+            "nullable" : true
+          }
+        }, {
+          "name" : "requestId",
+          "in" : "path",
+          "description" : "The request id",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The request id",
+            "nullable" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Result found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/InvocationResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Submodel / Operation / Request not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Result"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "KeyType" : {
+        "enum" : [ "Undefined", "Custom", "IRI", "URI", "IRDI", "IdShort", "FragmentId" ],
+        "type" : "string"
+      },
+      "Identifier" : {
+        "required" : [ "id", "idType" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "idType" : {
+            "$ref" : "#/components/schemas/KeyType"
+          }
+        }
+      },
+      "AdministrativeInformation" : {
+        "type" : "object",
+        "properties" : {
+          "version" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "revision" : {
+            "type" : "string",
+            "nullable" : true
+          }
+        }
+      },
+      "LangString" : {
+        "type" : "object",
+        "properties" : {
+          "language" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "text" : {
+            "type" : "string",
+            "nullable" : true
+          }
+        }
+      },
+      "IEndpointSecurity" : {
+        "type" : "object"
+      },
+      "IEndpoint" : {
+        "type" : "object",
+        "properties" : {
+          "address" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "type" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "security" : {
+            "$ref" : "#/components/schemas/IEndpointSecurity"
+          }
+        }
+      },
+      "ModelType" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          }
+        }
+      },
+      "AssetKind" : {
+        "enum" : [ "Type", "Instance" ],
+        "type" : "string"
+      },
+      "KeyElements" : {
+        "enum" : [ "Undefined", "GlobalReference", "FragmentReference", "AccessPermissionRule", "AnnotatedRelationshipElement", "BasicEvent", "Blob", "Capability", "ConceptDictionary", "DataElement", "File", "Entity", "Event", "MultiLanguageProperty", "Operation", "Property", "Range", "ReferenceElement", "RelationshipElement", "SubmodelElement", "SubmodelElementCollection", "View", "Asset", "AssetAdministrationShell", "ConceptDescription", "Submodel" ],
+        "type" : "string"
+      },
+      "Key" : {
+        "required" : [ "idType", "local", "type", "value" ],
+        "type" : "object",
+        "properties" : {
+          "type" : {
+            "$ref" : "#/components/schemas/KeyElements"
+          },
+          "idType" : {
+            "$ref" : "#/components/schemas/KeyType"
+          },
+          "value" : {
+            "type" : "string"
+          },
+          "local" : {
+            "type" : "boolean"
+          }
+        }
+      },
+      "SubmodelReference" : {
+        "type" : "object",
+        "properties" : {
+          "keys" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Key"
+            },
+            "nullable" : true
+          }
+        }
+      },
+      "Reference" : {
+        "type" : "object",
+        "properties" : {
+          "keys" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Key"
+            },
+            "nullable" : true
+          }
+        }
+      },
+      "IDataSpecificationContent" : {
+        "type" : "object"
+      },
+      "IEmbeddedDataSpecification" : {
+        "type" : "object",
+        "properties" : {
+          "hasDataSpecification" : {
+            "$ref" : "#/components/schemas/Reference"
+          },
+          "dataSpecificationContent" : {
+            "$ref" : "#/components/schemas/IDataSpecificationContent"
+          }
+        }
+      },
+      "Asset" : {
+        "type" : "object",
+        "properties" : {
+          "idShort" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "kind" : {
+            "$ref" : "#/components/schemas/AssetKind"
+          },
+          "assetIdentificationModel" : {
+            "$ref" : "#/components/schemas/SubmodelReference"
+          },
+          "billOfMaterial" : {
+            "$ref" : "#/components/schemas/SubmodelReference"
+          },
+          "embeddedDataSpecifications" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/IEmbeddedDataSpecification"
+            },
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "modelType" : {
+            "$ref" : "#/components/schemas/ModelType"
+          },
+          "identification" : {
+            "$ref" : "#/components/schemas/Identifier"
+          },
+          "administration" : {
+            "$ref" : "#/components/schemas/AdministrativeInformation"
+          },
+          "category" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "description" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/LangString"
+            },
+            "nullable" : true
+          }
+        }
+      },
+      "SubmodelDescriptor" : {
+        "type" : "object",
+        "properties" : {
+          "idShort" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "identification" : {
+            "$ref" : "#/components/schemas/Identifier"
+          },
+          "administration" : {
+            "$ref" : "#/components/schemas/AdministrativeInformation"
+          },
+          "description" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/LangString"
+            },
+            "nullable" : true
+          },
+          "semanticId" : {
+            "$ref" : "#/components/schemas/Reference"
+          },
+          "endpoints" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/IEndpoint"
+            },
+            "nullable" : true
+          },
+          "category" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "modelType" : {
+            "$ref" : "#/components/schemas/ModelType"
+          }
+        }
+      },
+      "AssetAdministrationShellDescriptor" : {
+        "type" : "object",
+        "properties" : {
+          "idShort" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "identification" : {
+            "$ref" : "#/components/schemas/Identifier"
+          },
+          "administration" : {
+            "$ref" : "#/components/schemas/AdministrativeInformation"
+          },
+          "description" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/LangString"
+            },
+            "nullable" : true
+          },
+          "endpoints" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/IEndpoint"
+            },
+            "nullable" : true
+          },
+          "category" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "modelType" : {
+            "$ref" : "#/components/schemas/ModelType"
+          },
+          "asset" : {
+            "$ref" : "#/components/schemas/Asset"
+          },
+          "submodels" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SubmodelDescriptor"
+            },
+            "nullable" : true
+          }
+        }
+      },
+      "ModelingKind" : {
+        "enum" : [ "Instance", "Template" ],
+        "type" : "string"
+      },
+      "IConstraint" : {
+        "type" : "object",
+        "properties" : {
+          "modelType" : {
+            "$ref" : "#/components/schemas/ModelType"
+          }
+        }
+      },
+      "ISubmodelElement" : {
+        "type" : "object",
+        "properties" : {
+          "idShort" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "semanticId" : {
+            "$ref" : "#/components/schemas/Reference"
+          },
+          "constraints" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/IConstraint"
+            },
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "description" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/LangString"
+            },
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "category" : {
+            "type" : "string",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "kind" : {
+            "$ref" : "#/components/schemas/ModelingKind"
+          },
+          "modelType" : {
+            "$ref" : "#/components/schemas/ModelType"
+          },
+          "embeddedDataSpecifications" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/IEmbeddedDataSpecification"
+            },
+            "nullable" : true,
+            "readOnly" : true
+          }
+        }
+      },
+      "Submodel" : {
+        "type" : "object",
+        "properties" : {
+          "idShort" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "kind" : {
+            "$ref" : "#/components/schemas/ModelingKind"
+          },
+          "semanticId" : {
+            "$ref" : "#/components/schemas/Reference"
+          },
+          "submodelElements" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ISubmodelElement"
+            },
+            "nullable" : true
+          },
+          "modelType" : {
+            "$ref" : "#/components/schemas/ModelType"
+          },
+          "embeddedDataSpecifications" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/IEmbeddedDataSpecification"
+            },
+            "nullable" : true
+          },
+          "qualifiers" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/IConstraint"
+            },
+            "nullable" : true
+          },
+          "identification" : {
+            "$ref" : "#/components/schemas/Identifier"
+          },
+          "administration" : {
+            "$ref" : "#/components/schemas/AdministrativeInformation"
+          },
+          "category" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "description" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/LangString"
+            },
+            "nullable" : true
+          }
+        }
+      },
+      "MessageType" : {
+        "enum" : [ "Unspecified", "Debug", "Information", "Warning", "Error", "Fatal", "Exception" ],
+        "type" : "string"
+      },
+      "Message" : {
+        "type" : "object",
+        "properties" : {
+          "messageType" : {
+            "$ref" : "#/components/schemas/MessageType"
+          },
+          "text" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "code" : {
+            "type" : "string",
+            "nullable" : true
+          }
+        }
+      },
+      "Result" : {
+        "type" : "object",
+        "properties" : {
+          "success" : {
+            "type" : "boolean"
+          },
+          "isException" : {
+            "type" : "boolean",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "entity" : {
+            "type" : "object",
+            "nullable" : true
+          },
+          "entityType" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "messages" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Message"
+            },
+            "nullable" : true
+          }
+        }
+      },
+      "SubmodelElement" : {
+        "type" : "object",
+        "properties" : {
+          "idShort" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "semanticId" : {
+            "$ref" : "#/components/schemas/Reference"
+          },
+          "qualifiers" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/IConstraint"
+            },
+            "nullable" : true
+          },
+          "kind" : {
+            "$ref" : "#/components/schemas/ModelingKind"
+          },
+          "modelType" : {
+            "$ref" : "#/components/schemas/ModelType"
+          },
+          "embeddedDataSpecifications" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/IEmbeddedDataSpecification"
+            },
+            "nullable" : true
+          },
+          "category" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "description" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/LangString"
+            },
+            "nullable" : true
+          }
+        }
+      },
+      "ElementValue" : {
+        "type" : "object",
+        "properties" : {
+          "value" : {
+            "type" : "object",
+            "nullable" : true
+          }
+        }
+      },
+      "OperationVariable" : {
+        "type" : "object",
+        "properties" : {
+          "modelType" : {
+            "$ref" : "#/components/schemas/ModelType"
+          },
+          "value" : {
+            "$ref" : "#/components/schemas/ISubmodelElement"
+          }
+        }
+      },
+      "InvocationRequest" : {
+        "type" : "object",
+        "properties" : {
+          "requestId" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "inputArguments" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/OperationVariable"
+            },
+            "nullable" : true
+          },
+          "inoutputArguments" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/OperationVariable"
+            },
+            "nullable" : true
+          },
+          "timeout" : {
+            "type" : "integer",
+            "format" : "int32",
+            "nullable" : true
+          }
+        }
+      },
+      "OperationResult" : {
+        "type" : "object",
+        "properties" : {
+          "success" : {
+            "type" : "boolean"
+          },
+          "isException" : {
+            "type" : "boolean",
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "entity" : {
+            "type" : "object",
+            "nullable" : true
+          },
+          "entityType" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "messages" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Message"
+            },
+            "nullable" : true
+          }
+        }
+      },
+      "ExecutionState" : {
+        "enum" : [ "Initiated", "Running", "Completed", "Canceled", "Failed", "Timeout" ],
+        "type" : "string"
+      },
+      "InvocationResponse" : {
+        "type" : "object",
+        "properties" : {
+          "requestId" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "inoutputArguments" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/OperationVariable"
+            },
+            "nullable" : true
+          },
+          "outputArguments" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/OperationVariable"
+            },
+            "nullable" : true
+          },
+          "operationResult" : {
+            "$ref" : "#/components/schemas/OperationResult"
+          },
+          "executionState" : {
+            "$ref" : "#/components/schemas/ExecutionState"
+          }
+        }
+      },
+      "AssetAdministrationShellReference" : {
+        "type" : "object",
+        "properties" : {
+          "keys" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Key"
+            },
+            "nullable" : true
+          }
+        }
+      },
+      "View" : {
+        "type" : "object",
+        "properties" : {
+          "idShort" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "containedElements" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Reference"
+            },
+            "nullable" : true
+          },
+          "semanticId" : {
+            "$ref" : "#/components/schemas/Reference"
+          },
+          "category" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "description" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/LangString"
+            },
+            "nullable" : true
+          },
+          "modelType" : {
+            "$ref" : "#/components/schemas/ModelType"
+          }
+        }
+      },
+      "ConceptDescriptionReference" : {
+        "type" : "object",
+        "properties" : {
+          "keys" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Key"
+            },
+            "nullable" : true
+          }
+        }
+      },
+      "ConceptDictionary" : {
+        "type" : "object",
+        "properties" : {
+          "idShort" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "category" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "description" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/LangString"
+            },
+            "nullable" : true
+          },
+          "metaData" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            },
+            "nullable" : true
+          },
+          "conceptDescriptions" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ConceptDescriptionReference"
+            },
+            "nullable" : true
+          },
+          "modelType" : {
+            "$ref" : "#/components/schemas/ModelType"
+          }
+        }
+      },
+      "AssetAdministrationShell" : {
+        "type" : "object",
+        "properties" : {
+          "idShort" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "asset" : {
+            "$ref" : "#/components/schemas/Asset"
+          },
+          "submodels" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Submodel"
+            },
+            "nullable" : true
+          },
+          "derivedFrom" : {
+            "$ref" : "#/components/schemas/AssetAdministrationShellReference"
+          },
+          "views" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/View"
+            },
+            "nullable" : true
+          },
+          "modelType" : {
+            "$ref" : "#/components/schemas/ModelType"
+          },
+          "embeddedDataSpecifications" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/IEmbeddedDataSpecification"
+            },
+            "nullable" : true,
+            "readOnly" : true
+          },
+          "conceptDictionaries" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ConceptDictionary"
+            },
+            "nullable" : true
+          },
+          "identification" : {
+            "$ref" : "#/components/schemas/Identifier"
+          },
+          "administration" : {
+            "$ref" : "#/components/schemas/AdministrativeInformation"
+          },
+          "category" : {
+            "type" : "string",
+            "nullable" : true
+          },
+          "description" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/LangString"
+            },
+            "nullable" : true
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/source/content/user_documentation/developer/basyx_java_v1/swagger/shared_models-v1.json
+++ b/docs/source/content/user_documentation/developer/basyx_java_v1/swagger/shared_models-v1.json
@@ -1,0 +1,1200 @@
+{
+  "openapi" : "3.0.0",
+  "info" : {
+    "title" : "BaSyx Shared Models",
+    "description" : "All BaSyx shared model classes including the classes of the Asset Administration Shell meta model",
+    "version" : "v1"
+  },
+  "components" : {
+    "schemas" : {
+      "Result" : {
+        "type" : "object",
+        "properties" : {
+          "entityType" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "entity" : {
+            "type" : "object",
+            "readOnly" : true
+          },
+          "success" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "isException" : {
+            "type" : "boolean",
+            "readOnly" : true
+          },
+          "messages" : {
+            "uniqueItems" : false,
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Message"
+            },
+            "readOnly" : true
+          }
+        }
+      },
+      "Message" : {
+        "type" : "object",
+        "properties" : {
+          "messageType" : {
+            "enum" : [ "Unspecified", "Debug", "Information", "Warning", "Error", "Fatal", "Exception" ],
+            "type" : "string"
+          },
+          "code" : {
+            "type" : "string"
+          },
+          "text" : {
+            "type" : "string"
+          }
+        }
+      },
+      "InvocationRequest" : {
+        "type" : "object",
+        "properties" : {
+          "requestId" : {
+            "type" : "string"
+          },
+          "inoutputArguments" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/OperationVariable"
+            }
+          },
+          "inputArguments" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/OperationVariable"
+            }
+          },
+          "timeout" : {
+            "type" : "integer"
+          }
+        }
+      },
+      "CallbackReponse" : {
+        "type" : "object",
+        "properties" : {
+          "requestId" : {
+            "type" : "string"
+          },
+          "callbackUrl" : {
+            "type" : "string"
+          }
+        }
+      },
+      "InvocationResponse" : {
+        "type" : "object",
+        "properties" : {
+          "requestId" : {
+            "type" : "string"
+          },
+          "inoutputArguments" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/OperationVariable"
+            }
+          },
+          "outputArguments" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/OperationVariable"
+            }
+          },
+          "operationResult" : {
+            "$ref" : "#/components/schemas/Result"
+          },
+          "executionState" : {
+            "type" : "string",
+            "enum" : [ "Initiated", "Running", "Completed", "Canceled", "Failed", "Timeout" ]
+          }
+        }
+      },
+      "EventSubscription" : {
+        "type" : "object",
+        "properties" : {
+          "clientId" : {
+            "type" : "string"
+          },
+          "endpoint" : {
+            "$ref" : "#/components/schemas/Endpoint"
+          }
+        }
+      },
+      "AssetAdministrationShellDescriptor" : {
+        "type" : "object",
+        "properties" : {
+          "idShort" : {
+            "type" : "string"
+          },
+          "identification" : {
+            "$ref" : "#/components/schemas/Identifier"
+          },
+          "administration" : {
+            "$ref" : "#/components/schemas/AdministrativeInformation"
+          },
+          "description" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/LangString"
+            }
+          },
+          "asset" : {
+            "$ref" : "#/components/schemas/Asset"
+          },
+          "endpoints" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Endpoint"
+            }
+          },
+          "submodelDescriptors" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SubmodelDescriptor"
+            }
+          }
+        }
+      },
+      "SubmodelDescriptor" : {
+        "type" : "object",
+        "properties" : {
+          "idShort" : {
+            "type" : "string"
+          },
+          "identification" : {
+            "$ref" : "#/components/schemas/Identifier"
+          },
+          "administration" : {
+            "$ref" : "#/components/schemas/AdministrativeInformation"
+          },
+          "description" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/LangString"
+            }
+          },
+          "semanticId" : {
+            "$ref" : "#/components/schemas/Reference"
+          },
+          "endpoints" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Endpoint"
+            }
+          }
+        }
+      },
+      "Endpoint" : {
+        "type" : "object",
+        "properties" : {
+          "address" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string"
+          },
+          "parameters" : {
+            "type" : "object"
+          }
+        }
+      },
+      "Referable" : {
+        "type" : "object",
+        "properties" : {
+          "idShort" : {
+            "type" : "string"
+          },
+          "category" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/LangString"
+            }
+          },
+          "parent" : {
+            "$ref" : "#/components/schemas/Reference"
+          },
+          "modelType" : {
+            "$ref" : "#/components/schemas/ModelType"
+          }
+        },
+        "required" : [ "idShort", "modelType" ]
+      },
+      "Identifiable" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Referable"
+        }, {
+          "properties" : {
+            "identification" : {
+              "$ref" : "#/components/schemas/Identifier"
+            },
+            "administration" : {
+              "$ref" : "#/components/schemas/AdministrativeInformation"
+            }
+          },
+          "required" : [ "identification" ]
+        } ]
+      },
+      "Qualifiable" : {
+        "type" : "object",
+        "properties" : {
+          "qualifiers" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Constraint"
+            }
+          }
+        }
+      },
+      "HasSemantics" : {
+        "type" : "object",
+        "properties" : {
+          "semanticId" : {
+            "$ref" : "#/components/schemas/Reference"
+          }
+        }
+      },
+      "HasDataSpecification" : {
+        "type" : "object",
+        "properties" : {
+          "embeddedDataSpecifications" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/EmbeddedDataSpecification"
+            }
+          }
+        }
+      },
+      "AssetAdministrationShell" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Identifiable"
+        }, {
+          "$ref" : "#/components/schemas/HasDataSpecification"
+        }, {
+          "properties" : {
+            "derivedFrom" : {
+              "$ref" : "#/components/schemas/Reference"
+            },
+            "asset" : {
+              "$ref" : "#/components/schemas/Reference"
+            },
+            "submodels" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/Reference"
+              }
+            },
+            "views" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/View"
+              }
+            },
+            "conceptDictionaries" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/ConceptDictionary"
+              }
+            },
+            "security" : {
+              "$ref" : "#/components/schemas/Security"
+            }
+          },
+          "required" : [ "asset" ]
+        } ]
+      },
+      "Identifier" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "idType" : {
+            "$ref" : "#/components/schemas/KeyType"
+          }
+        },
+        "required" : [ "id", "idType" ]
+      },
+      "KeyType" : {
+        "type" : "string",
+        "enum" : [ "Custom", "IRDI", "IRI", "IdShort", "FragmentId" ]
+      },
+      "AdministrativeInformation" : {
+        "type" : "object",
+        "properties" : {
+          "version" : {
+            "type" : "string"
+          },
+          "revision" : {
+            "type" : "string"
+          }
+        }
+      },
+      "LangString" : {
+        "type" : "object",
+        "properties" : {
+          "language" : {
+            "type" : "string"
+          },
+          "text" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "language", "text" ]
+      },
+      "Reference" : {
+        "type" : "object",
+        "properties" : {
+          "keys" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Key"
+            }
+          }
+        },
+        "required" : [ "keys" ]
+      },
+      "Key" : {
+        "type" : "object",
+        "properties" : {
+          "type" : {
+            "$ref" : "#/components/schemas/KeyElements"
+          },
+          "idType" : {
+            "$ref" : "#/components/schemas/KeyType"
+          },
+          "value" : {
+            "type" : "string"
+          },
+          "local" : {
+            "type" : "boolean"
+          }
+        },
+        "required" : [ "type", "idType", "value", "local" ]
+      },
+      "KeyElements" : {
+        "type" : "string",
+        "enum" : [ "Asset", "AssetAdministrationShell", "ConceptDescription", "Submodel", "AccessPermissionRule", "AnnotatedRelationshipElement", "BasicEvent", "Blob", "Capability", "ConceptDictionary", "DataElement", "File", "Entity", "Event", "MultiLanguageProperty", "Operation", "Property", "Range", "ReferenceElement", "RelationshipElement", "SubmodelElement", "SubmodelElementCollection", "View", "GlobalReference", "FragmentReference" ]
+      },
+      "ModelTypes" : {
+        "type" : "string",
+        "enum" : [ "Asset", "AssetAdministrationShell", "ConceptDescription", "Submodel", "AccessPermissionRule", "AnnotatedRelationshipElement", "BasicEvent", "Blob", "Capability", "ConceptDictionary", "DataElement", "File", "Entity", "Event", "MultiLanguageProperty", "Operation", "Property", "Range", "ReferenceElement", "RelationshipElement", "SubmodelElement", "SubmodelElementCollection", "View", "GlobalReference", "FragmentReference", "Constraint", "Formula", "Qualifier" ]
+      },
+      "ModelType" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "$ref" : "#/components/schemas/ModelTypes"
+          }
+        },
+        "required" : [ "name" ]
+      },
+      "EmbeddedDataSpecification" : {
+        "type" : "object",
+        "properties" : {
+          "dataSpecification" : {
+            "$ref" : "#/components/schemas/Reference"
+          },
+          "dataSpecificationContent" : {
+            "$ref" : "#/components/schemas/DataSpecificationContent"
+          }
+        },
+        "required" : [ "dataSpecification", "dataSpecificationContent" ]
+      },
+      "DataSpecificationContent" : {
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/DataSpecificationIEC61360Content"
+        }, {
+          "$ref" : "#/components/schemas/DataSpecificationPhysicalUnitContent"
+        } ]
+      },
+      "DataSpecificationPhysicalUnitContent" : {
+        "type" : "object",
+        "properties" : {
+          "unitName" : {
+            "type" : "string"
+          },
+          "unitSymbol" : {
+            "type" : "string"
+          },
+          "definition" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/LangString"
+            }
+          },
+          "siNotation" : {
+            "type" : "string"
+          },
+          "siName" : {
+            "type" : "string"
+          },
+          "dinNotation" : {
+            "type" : "string"
+          },
+          "eceName" : {
+            "type" : "string"
+          },
+          "eceCode" : {
+            "type" : "string"
+          },
+          "nistName" : {
+            "type" : "string"
+          },
+          "sourceOfDefinition" : {
+            "type" : "string"
+          },
+          "conversionFactor" : {
+            "type" : "string"
+          },
+          "registrationAuthorityId" : {
+            "type" : "string"
+          },
+          "supplier" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "unitName", "unitSymbol", "definition" ]
+      },
+      "DataSpecificationIEC61360Content" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/ValueObject"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "dataType" : {
+              "enum" : [ "DATE", "STRING", "STRING_TRANSLATABLE", "REAL_MEASURE", "REAL_COUNT", "REAL_CURRENCY", "BOOLEAN", "URL", "RATIONAL", "RATIONAL_MEASURE", "TIME", "TIMESTAMP" ]
+            },
+            "definition" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/LangString"
+              }
+            },
+            "preferredName" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/LangString"
+              }
+            },
+            "shortName" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/LangString"
+              }
+            },
+            "sourceOfDefinition" : {
+              "type" : "string"
+            },
+            "symbol" : {
+              "type" : "string"
+            },
+            "unit" : {
+              "type" : "string"
+            },
+            "unitId" : {
+              "$ref" : "#/components/schemas/Reference"
+            },
+            "valueFormat" : {
+              "type" : "string"
+            },
+            "valueList" : {
+              "$ref" : "#/components/schemas/ValueList"
+            },
+            "levelType" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/LevelType"
+              }
+            }
+          },
+          "required" : [ "preferredName" ]
+        } ]
+      },
+      "LevelType" : {
+        "type" : "string",
+        "enum" : [ "Min", "Max", "Nom", "Typ" ]
+      },
+      "ValueList" : {
+        "type" : "object",
+        "properties" : {
+          "valueReferencePairTypes" : {
+            "type" : "array",
+            "minItems" : 1,
+            "items" : {
+              "$ref" : "#/components/schemas/ValueReferencePairType"
+            }
+          }
+        },
+        "required" : [ "valueReferencePairTypes" ]
+      },
+      "ValueReferencePairType" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/ValueObject"
+        } ]
+      },
+      "ValueObject" : {
+        "type" : "object",
+        "properties" : {
+          "value" : {
+            "type" : "string"
+          },
+          "valueId" : {
+            "$ref" : "#/components/schemas/Reference"
+          },
+          "valueType" : {
+            "type" : "string",
+            "enum" : [ "anyUri", "base64Binary", "boolean", "date", "dateTime", "dateTimeStamp", "decimal", "integer", "long", "int", "short", "byte", "nonNegativeInteger", "positiveInteger", "unsignedLong", "unsignedInt", "unsignedShort", "unsignedByte", "nonPositiveInteger", "negativeInteger", "double", "duration", "dayTimeDuration", "yearMonthDuration", "float", "gDay", "gMonth", "gMonthDay", "gYear", "gYearMonth", "hexBinary", "NOTATION", "QName", "string", "normalizedString", "token", "language", "Name", "NCName", "ENTITY", "ID", "IDREF", "NMTOKEN", "time" ]
+          }
+        }
+      },
+      "Asset" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Identifiable"
+        }, {
+          "$ref" : "#/components/schemas/HasDataSpecification"
+        }, {
+          "properties" : {
+            "kind" : {
+              "$ref" : "#/components/schemas/AssetKind"
+            },
+            "assetIdentificationModel" : {
+              "$ref" : "#/components/schemas/Reference"
+            },
+            "billOfMaterial" : {
+              "$ref" : "#/components/schemas/Reference"
+            }
+          },
+          "required" : [ "kind" ]
+        } ]
+      },
+      "AssetKind" : {
+        "type" : "string",
+        "enum" : [ "Type", "Instance" ]
+      },
+      "ModelingKind" : {
+        "type" : "string",
+        "enum" : [ "Template", "Instance" ]
+      },
+      "Submodel" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Identifiable"
+        }, {
+          "$ref" : "#/components/schemas/HasDataSpecification"
+        }, {
+          "$ref" : "#/components/schemas/Qualifiable"
+        }, {
+          "$ref" : "#/components/schemas/HasSemantics"
+        }, {
+          "properties" : {
+            "kind" : {
+              "$ref" : "#/components/schemas/ModelingKind"
+            },
+            "submodelElements" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/SubmodelElement"
+              }
+            }
+          }
+        } ]
+      },
+      "Constraint" : {
+        "type" : "object",
+        "properties" : {
+          "modelType" : {
+            "$ref" : "#/components/schemas/ModelType"
+          }
+        },
+        "required" : [ "modelType" ]
+      },
+      "Operation" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/SubmodelElement"
+        }, {
+          "properties" : {
+            "inputVariable" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/OperationVariable"
+              }
+            },
+            "outputVariable" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/OperationVariable"
+              }
+            },
+            "inoutputVariable" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/OperationVariable"
+              }
+            }
+          }
+        } ]
+      },
+      "OperationVariable" : {
+        "type" : "object",
+        "properties" : {
+          "value" : {
+            "oneOf" : [ {
+              "$ref" : "#/components/schemas/Blob"
+            }, {
+              "$ref" : "#/components/schemas/File"
+            }, {
+              "$ref" : "#/components/schemas/Capability"
+            }, {
+              "$ref" : "#/components/schemas/Entity"
+            }, {
+              "$ref" : "#/components/schemas/Event"
+            }, {
+              "$ref" : "#/components/schemas/BasicEvent"
+            }, {
+              "$ref" : "#/components/schemas/MultiLanguageProperty"
+            }, {
+              "$ref" : "#/components/schemas/Operation"
+            }, {
+              "$ref" : "#/components/schemas/Property"
+            }, {
+              "$ref" : "#/components/schemas/Range"
+            }, {
+              "$ref" : "#/components/schemas/ReferenceElement"
+            }, {
+              "$ref" : "#/components/schemas/RelationshipElement"
+            }, {
+              "$ref" : "#/components/schemas/SubmodelElementCollection"
+            } ]
+          }
+        },
+        "required" : [ "value" ]
+      },
+      "SubmodelElement" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Referable"
+        }, {
+          "$ref" : "#/components/schemas/HasDataSpecification"
+        }, {
+          "$ref" : "#/components/schemas/HasSemantics"
+        }, {
+          "$ref" : "#/components/schemas/Qualifiable"
+        }, {
+          "properties" : {
+            "kind" : {
+              "$ref" : "#/components/schemas/ModelingKind"
+            }
+          }
+        } ]
+      },
+      "Event" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/SubmodelElement"
+        } ]
+      },
+      "BasicEvent" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Event"
+        }, {
+          "properties" : {
+            "observed" : {
+              "$ref" : "#/components/schemas/Reference"
+            }
+          },
+          "required" : [ "observed" ]
+        } ]
+      },
+      "EntityType" : {
+        "type" : "string",
+        "enum" : [ "CoManagedEntity", "SelfManagedEntity" ]
+      },
+      "Entity" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/SubmodelElement"
+        }, {
+          "properties" : {
+            "statements" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/SubmodelElement"
+              }
+            },
+            "entityType" : {
+              "$ref" : "#/components/schemas/EntityType"
+            },
+            "asset" : {
+              "$ref" : "#/components/schemas/Reference"
+            }
+          },
+          "required" : [ "entityType" ]
+        } ]
+      },
+      "View" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Referable"
+        }, {
+          "$ref" : "#/components/schemas/HasDataSpecification"
+        }, {
+          "$ref" : "#/components/schemas/HasSemantics"
+        }, {
+          "properties" : {
+            "containedElements" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/Reference"
+              }
+            }
+          }
+        } ]
+      },
+      "ConceptDictionary" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Referable"
+        }, {
+          "$ref" : "#/components/schemas/HasDataSpecification"
+        }, {
+          "properties" : {
+            "conceptDescriptions" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/Reference"
+              }
+            }
+          }
+        } ]
+      },
+      "ConceptDescription" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Identifiable"
+        }, {
+          "$ref" : "#/components/schemas/HasDataSpecification"
+        }, {
+          "properties" : {
+            "isCaseOf" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/Reference"
+              }
+            }
+          }
+        } ]
+      },
+      "Capability" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/SubmodelElement"
+        } ]
+      },
+      "Property" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/SubmodelElement"
+        }, {
+          "$ref" : "#/components/schemas/ValueObject"
+        } ]
+      },
+      "Range" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/SubmodelElement"
+        }, {
+          "properties" : {
+            "valueType" : {
+              "type" : "string",
+              "enum" : [ "anyUri", "base64Binary", "boolean", "date", "dateTime", "dateTimeStamp", "decimal", "integer", "long", "int", "short", "byte", "nonNegativeInteger", "positiveInteger", "unsignedLong", "unsignedInt", "unsignedShort", "unsignedByte", "nonPositiveInteger", "negativeInteger", "double", "duration", "dayTimeDuration", "yearMonthDuration", "float", "gDay", "gMonth", "gMonthDay", "gYear", "gYearMonth", "hexBinary", "NOTATION", "QName", "string", "normalizedString", "token", "language", "Name", "NCName", "ENTITY", "ID", "IDREF", "NMTOKEN", "time" ]
+            },
+            "min" : {
+              "type" : "string"
+            },
+            "max" : {
+              "type" : "string"
+            }
+          },
+          "required" : [ "valueType", "min", "max" ]
+        } ]
+      },
+      "MultiLanguageProperty" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/SubmodelElement"
+        }, {
+          "properties" : {
+            "value" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/LangString"
+              }
+            },
+            "valueId" : {
+              "$ref" : "#/components/schemas/Reference"
+            }
+          }
+        } ]
+      },
+      "File" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/SubmodelElement"
+        }, {
+          "properties" : {
+            "value" : {
+              "type" : "string"
+            },
+            "mimeType" : {
+              "type" : "string"
+            }
+          },
+          "required" : [ "mimeType", "value" ]
+        } ]
+      },
+      "Blob" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/SubmodelElement"
+        }, {
+          "properties" : {
+            "value" : {
+              "type" : "string"
+            },
+            "mimeType" : {
+              "type" : "string"
+            }
+          },
+          "required" : [ "mimeType", "value" ]
+        } ]
+      },
+      "ReferenceElement" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/SubmodelElement"
+        }, {
+          "properties" : {
+            "value" : {
+              "$ref" : "#/components/schemas/Reference"
+            }
+          }
+        } ]
+      },
+      "SubmodelElementCollection" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/SubmodelElement"
+        }, {
+          "properties" : {
+            "value" : {
+              "type" : "array",
+              "items" : {
+                "oneOf" : [ {
+                  "$ref" : "#/components/schemas/Blob"
+                }, {
+                  "$ref" : "#/components/schemas/File"
+                }, {
+                  "$ref" : "#/components/schemas/Capability"
+                }, {
+                  "$ref" : "#/components/schemas/Entity"
+                }, {
+                  "$ref" : "#/components/schemas/Event"
+                }, {
+                  "$ref" : "#/components/schemas/BasicEvent"
+                }, {
+                  "$ref" : "#/components/schemas/MultiLanguageProperty"
+                }, {
+                  "$ref" : "#/components/schemas/Operation"
+                }, {
+                  "$ref" : "#/components/schemas/Property"
+                }, {
+                  "$ref" : "#/components/schemas/Range"
+                }, {
+                  "$ref" : "#/components/schemas/ReferenceElement"
+                }, {
+                  "$ref" : "#/components/schemas/RelationshipElement"
+                }, {
+                  "$ref" : "#/components/schemas/SubmodelElementCollection"
+                } ]
+              }
+            },
+            "allowDuplicates" : {
+              "type" : "boolean"
+            },
+            "ordered" : {
+              "type" : "boolean"
+            }
+          }
+        } ]
+      },
+      "RelationshipElement" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/SubmodelElement"
+        }, {
+          "properties" : {
+            "first" : {
+              "$ref" : "#/components/schemas/Reference"
+            },
+            "second" : {
+              "$ref" : "#/components/schemas/Reference"
+            }
+          },
+          "required" : [ "first", "second" ]
+        } ]
+      },
+      "AnnotatedRelationshipElement" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/RelationshipElement"
+        }, {
+          "properties" : {
+            "annotation" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/Reference"
+              }
+            }
+          }
+        } ]
+      },
+      "Qualifier" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Constraint"
+        }, {
+          "$ref" : "#/components/schemas/HasSemantics"
+        }, {
+          "$ref" : "#/components/schemas/ValueObject"
+        }, {
+          "properties" : {
+            "type" : {
+              "type" : "string"
+            }
+          },
+          "required" : [ "type" ]
+        } ]
+      },
+      "Formula" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Constraint"
+        }, {
+          "properties" : {
+            "dependsOn" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/Reference"
+              }
+            }
+          }
+        } ]
+      },
+      "Security" : {
+        "type" : "object",
+        "properties" : {
+          "accessControlPolicyPoints" : {
+            "$ref" : "#/components/schemas/AccessControlPolicyPoints"
+          },
+          "certificate" : {
+            "type" : "array",
+            "items" : {
+              "oneOf" : [ {
+                "$ref" : "#/components/schemas/BlobCertificate"
+              } ]
+            }
+          },
+          "requiredCertificateExtension" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Reference"
+            }
+          }
+        },
+        "required" : [ "accessControlPolicyPoints" ]
+      },
+      "Certificate" : {
+        "type" : "object"
+      },
+      "BlobCertificate" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Certificate"
+        }, {
+          "properties" : {
+            "blobCertificate" : {
+              "$ref" : "#/components/schemas/Blob"
+            },
+            "containedExtension" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/Reference"
+              }
+            },
+            "lastCertificate" : {
+              "type" : "boolean"
+            }
+          }
+        } ]
+      },
+      "AccessControlPolicyPoints" : {
+        "type" : "object",
+        "properties" : {
+          "policyAdministrationPoint" : {
+            "$ref" : "#/components/schemas/PolicyAdministrationPoint"
+          },
+          "policyDecisionPoint" : {
+            "$ref" : "#/components/schemas/PolicyDecisionPoint"
+          },
+          "policyEnforcementPoint" : {
+            "$ref" : "#/components/schemas/PolicyEnforcementPoint"
+          },
+          "policyInformationPoints" : {
+            "$ref" : "#/components/schemas/PolicyInformationPoints"
+          }
+        },
+        "required" : [ "policyAdministrationPoint", "policyDecisionPoint", "policyEnforcementPoint" ]
+      },
+      "PolicyAdministrationPoint" : {
+        "type" : "object",
+        "properties" : {
+          "localAccessControl" : {
+            "$ref" : "#/components/schemas/AccessControl"
+          },
+          "externalAccessControl" : {
+            "type" : "boolean"
+          }
+        },
+        "required" : [ "externalAccessControl" ]
+      },
+      "PolicyInformationPoints" : {
+        "type" : "object",
+        "properties" : {
+          "internalInformationPoint" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Reference"
+            }
+          },
+          "externalInformationPoint" : {
+            "type" : "boolean"
+          }
+        },
+        "required" : [ "externalInformationPoint" ]
+      },
+      "PolicyEnforcementPoint" : {
+        "type" : "object",
+        "properties" : {
+          "externalPolicyEnforcementPoint" : {
+            "type" : "boolean"
+          }
+        },
+        "required" : [ "externalPolicyEnforcementPoint" ]
+      },
+      "PolicyDecisionPoint" : {
+        "type" : "object",
+        "properties" : {
+          "externalPolicyDecisionPoints" : {
+            "type" : "boolean"
+          }
+        },
+        "required" : [ "externalPolicyDecisionPoints" ]
+      },
+      "AccessControl" : {
+        "type" : "object",
+        "properties" : {
+          "selectableSubjectAttributes" : {
+            "$ref" : "#/components/schemas/Reference"
+          },
+          "defaultSubjectAttributes" : {
+            "$ref" : "#/components/schemas/Reference"
+          },
+          "selectablePermissions" : {
+            "$ref" : "#/components/schemas/Reference"
+          },
+          "defaultPermissions" : {
+            "$ref" : "#/components/schemas/Reference"
+          },
+          "selectableEnvironmentAttributes" : {
+            "$ref" : "#/components/schemas/Reference"
+          },
+          "defaultEnvironmentAttributes" : {
+            "$ref" : "#/components/schemas/Reference"
+          },
+          "accessPermissionRule" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/AccessPermissionRule"
+            }
+          }
+        }
+      },
+      "AccessPermissionRule" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/Referable"
+        }, {
+          "$ref" : "#/components/schemas/Qualifiable"
+        }, {
+          "properties" : {
+            "targetSubjectAttributes" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/SubjectAttributes"
+              },
+              "minItems" : 1
+            },
+            "permissionsPerObject" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/PermissionsPerObject"
+              }
+            }
+          },
+          "required" : [ "targetSubjectAttributes" ]
+        } ]
+      },
+      "SubjectAttributes" : {
+        "type" : "object",
+        "properties" : {
+          "subjectAttributes" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Reference"
+            },
+            "minItems" : 1
+          }
+        }
+      },
+      "PermissionsPerObject" : {
+        "type" : "object",
+        "properties" : {
+          "object" : {
+            "$ref" : "#/components/schemas/Reference"
+          },
+          "targetObjectAttributes" : {
+            "$ref" : "#/components/schemas/ObjectAttributes"
+          },
+          "permission" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Permission"
+            }
+          }
+        }
+      },
+      "ObjectAttributes" : {
+        "type" : "object",
+        "properties" : {
+          "objectAttribute" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Property"
+            },
+            "minItems" : 1
+          }
+        }
+      },
+      "Permission" : {
+        "type" : "object",
+        "properties" : {
+          "permission" : {
+            "$ref" : "#/components/schemas/Reference"
+          },
+          "kindOfPermission" : {
+            "type" : "string",
+            "enum" : [ "Allow", "Deny", "NotApplicable", "Undefined" ]
+          }
+        },
+        "required" : [ "permission", "kindOfPermission" ]
+      }
+    },
+    "links" : { },
+    "callbacks" : { }
+  }
+}


### PR DESCRIPTION
Exported unresolved JSON from swagger for the 6 Basyx API docs available and added them to the v1 docs folder. Added links to open them in the "index.md" file for "basyx_java_v1" (docs\source\content\user_documentation\developer\basyx_java_v1).

1. BaSyx Asset Administration Shell Repository HTTP REST-API
2. BaSyx Submodel HTTP REST-API
3. BaSyx Shared Models
4. BaSyx Submodel Repository HTTP REST-API
5. BaSyx Asset Administration Shell HTTP REST-API
6. BaSyx Registry HTTP REST-API