### PR TITLE
Update BaSyx-Python SDK developer article

### DIFF
--- a/docs/source/content/user_documentation/developer/basyx_python_sdk/index.md
+++ b/docs/source/content/user_documentation/developer/basyx_python_sdk/index.md
@@ -2,6 +2,10 @@
 
 This documentation provides a step-by-step guide for setting up an AAS (Asset Administration Shell) & Submodel Creation System, running an API server using the BaSyx Python SDK, and visualizing the data using Dash (web-based visualization). An **interactive Jupyter Notebook** is available, allowing users to execute and experiment with the setup step by step.
 
+For more examples and detailed explanations, see:
+- BaSyx Python SDK [Tutorials](https://github.com/eclipse-basyx/basyx-python-sdk/blob/main/sdk/README.md#examples-and-tutorials)
+- BaSyx Python SDK [Documentation](https://basyx-python-sdk.readthedocs.io/en/latest/)
+
 ## Overview
 
 ### **Jupyter Notebook for Interactive Execution**


### PR DESCRIPTION
This adds a small paragraph with links to more examples and detailed explanation to the BaSyx Python SDK article, namely to the official BaSyx Python SDK tutorials and documentation. 

The idea behind this is so that developers have an easier flow from their first steps in Jupyter Notebook to more detailed information.