### PR TITLE
Adds Documentation for Config Service and adapts Configuration Wiki

### DIFF
--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/architecture.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/architecture.md
@@ -1,0 +1,42 @@
+# Architecture Overview
+
+The BaSyx Configuration Service is a one-shot command-line service. It does not expose API endpoints and does not run as a daemon.
+
+## Main Components
+
+| Component | Location | Responsibility |
+| --- | --- | --- |
+| Service entry point | `cmd/basyxconfigurationservice/main.go` | Parses flags, creates the shared execution context, registers sequences, executes the initializer. |
+| Schema initializer | `internal/basyxconfigurationservice/schema_initializer.go` | Stores ordered sequences and executes them one after another. |
+| Sequence interface | `internal/basyxconfigurationservice/sequences/i_sequence.go` | Defines the executable contract for initialization steps. |
+| Execution context | `internal/basyxconfigurationservice/sequences/execution_context.go` | Shares loaded configuration and the database handle between sequences. |
+| Database connection sequence | `internal/basyxconfigurationservice/sequences/database.go` | Loads config, builds the PostgreSQL DSN, opens the database connection, applies pool settings. |
+| System table sequence | `internal/basyxconfigurationservice/sequences/system_table.go` | Creates and seeds `basyxsystem` when required. |
+| Schema upload sequence | `internal/basyxconfigurationservice/sequences/schema_upload.go` | Uploads `base.sql` when the base schema is not initialized. |
+| Schema patch sequence | `internal/basyxconfigurationservice/sequences/schema_patch.go` | Applies a registered patch when the database version is older than the patch target version. |
+
+## Component Diagram
+
+```mermaid
+flowchart TD
+    Main[cmd/basyxconfigurationservice/main.go] --> Initializer[SchemaInitializer]
+    Main --> Context[ExecutionContext]
+    Initializer --> DBSeq[DatabaseConnection Sequence]
+    Initializer --> SystemSeq[SystemTable Sequence]
+    Initializer --> UploadSeq[SchemaUpload Sequence]
+    Initializer --> PatchSeq[SchemaPatch Sequence]
+    DBSeq --> Context
+    SystemSeq --> Context
+    UploadSeq --> Context
+    PatchSeq --> Context
+    Context --> Postgres[(PostgreSQL)]
+    UploadSeq --> BaseSQL[database/base.sql]
+    PatchSeq --> PatchSQL[database/patches/*.sql]
+```
+
+## Interaction Overview
+
+The entry point registers sequences explicitly. The initializer does not discover sequences automatically. Each sequence receives the same `ExecutionContext`, allowing earlier sequences to provide state for later sequences.
+
+The database connection sequence populates the context with `Config` and `DB`. All later database-related sequences require `ctx.DB` to be set.
+

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/architecture.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/architecture.md
@@ -4,39 +4,36 @@ The BaSyx Configuration Service is a one-shot command-line service. It does not 
 
 ## Main Components
 
-| Component | Location | Responsibility |
-| --- | --- | --- |
-| Service entry point | `cmd/basyxconfigurationservice/main.go` | Parses flags, creates the shared execution context, registers sequences, executes the initializer. |
-| Schema initializer | `internal/basyxconfigurationservice/schema_initializer.go` | Stores ordered sequences and executes them one after another. |
-| Sequence interface | `internal/basyxconfigurationservice/sequences/i_sequence.go` | Defines the executable contract for initialization steps. |
-| Execution context | `internal/basyxconfigurationservice/sequences/execution_context.go` | Shares loaded configuration and the database handle between sequences. |
-| Database connection sequence | `internal/basyxconfigurationservice/sequences/database.go` | Loads config, builds the PostgreSQL DSN, opens the database connection, applies pool settings. |
-| System table sequence | `internal/basyxconfigurationservice/sequences/system_table.go` | Creates and seeds `basyxsystem` when required. |
-| Schema upload sequence | `internal/basyxconfigurationservice/sequences/schema_upload.go` | Uploads `base.sql` when the base schema is not initialized. |
-| Schema patch sequence | `internal/basyxconfigurationservice/sequences/schema_patch.go` | Applies a registered patch when the database version is older than the patch target version. |
-
-## Component Diagram
-
-```mermaid
-flowchart TD
-    Main[cmd/basyxconfigurationservice/main.go] --> Initializer[SchemaInitializer]
-    Main --> Context[ExecutionContext]
-    Initializer --> DBSeq[DatabaseConnection Sequence]
-    Initializer --> SystemSeq[SystemTable Sequence]
-    Initializer --> UploadSeq[SchemaUpload Sequence]
-    Initializer --> PatchSeq[SchemaPatch Sequence]
-    DBSeq --> Context
-    SystemSeq --> Context
-    UploadSeq --> Context
-    PatchSeq --> Context
-    Context --> Postgres[(PostgreSQL)]
-    UploadSeq --> BaseSQL[database/base.sql]
-    PatchSeq --> PatchSQL[database/patches/*.sql]
+```{uml} charts/configuration_service_architecture.puml
 ```
+
+| No. | Component | Responsibility |
+| --- | --- | --- |
+| 1 | Service entry point | Parses flags, creates the shared execution context, registers sequences, and executes the initializer. |
+| 2 | Schema initializer | Stores ordered sequences and executes them one after another. |
+| 3 | Sequence interface | Defines the executable contract for initialization steps. |
+| 4 | Execution context | Shares loaded configuration and the database handle between sequences. |
+| 5 | Database connection sequence | Loads config, builds the PostgreSQL DSN, opens the database connection, and applies pool settings. |
+| 6 | System table sequence | Creates and seeds `basyxsystem` when required. |
+| 7 | Schema upload sequence | Uploads `base.sql` when the base schema is not initialized. |
+| 8 | Schema patch sequence | Applies a registered patch when the database version is older than the patch target version. |
+| 9 | PostgreSQL database | Stores the BaSyx schema, system version row, and application data. |
+| 10 | Configuration object | Holds the loaded service and PostgreSQL settings used by later sequences. |
+| 11 | Database handle object | Provides the opened PostgreSQL connection handle stored in the execution context. |
+
+Implementation locations:
+
+- 1: `cmd/basyxconfigurationservice/main.go`
+- 2: `internal/basyxconfigurationservice/schema_initializer.go`
+- 3: `internal/basyxconfigurationservice/sequences/i_sequence.go`
+- 4: `internal/basyxconfigurationservice/sequences/execution_context.go`
+- 5: `internal/basyxconfigurationservice/sequences/database.go`
+- 6: `internal/basyxconfigurationservice/sequences/system_table.go`
+- 7: `internal/basyxconfigurationservice/sequences/schema_upload.go`
+- 8: `internal/basyxconfigurationservice/sequences/schema_patch.go`
 
 ## Interaction Overview
 
 The entry point registers sequences explicitly. The initializer does not discover sequences automatically. Each sequence receives the same `ExecutionContext`, allowing earlier sequences to provide state for later sequences.
 
-The database connection sequence populates the context with `Config` and `DB`. All later database-related sequences require `ctx.DB` to be set.
-
+The database connection sequence populates the context with `Config` and `DB`. `Config` provides the loaded configuration values, especially PostgreSQL connection and pool settings. `DB` is the opened PostgreSQL handle used by all later database-related sequences to execute SQL against PostgreSQL.

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/architecture.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/architecture.md
@@ -34,6 +34,6 @@ Implementation locations:
 
 ## Interaction Overview
 
-The entry point registers sequences explicitly. The initializer does not discover sequences automatically. Each sequence receives the same `ExecutionContext`, allowing earlier sequences to provide state for later sequences.
+The entry point (`main.go`) registers sequences explicitly. The initializer does not discover sequences automatically. Each sequence receives the same `ExecutionContext`, allowing earlier sequences to provide state for later sequences.
 
 The database connection sequence populates the context with `Config` and `DB`. `Config` provides the loaded configuration values, especially PostgreSQL connection and pool settings. `DB` is the opened PostgreSQL handle used by all later database-related sequences to execute SQL against PostgreSQL.

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/charts/configuration_service_architecture.puml
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/charts/configuration_service_architecture.puml
@@ -1,0 +1,37 @@
+@startuml
+skinparam componentStyle rectangle
+
+component "1\nmain.go" as Main
+component "2\nSchemaInitializer" as Initializer
+interface "3\nSequence" as Sequence
+component "4\nExecutionContext" as Context
+component "5\nDatabaseConnection" as DBSeq
+component "6\nSystemTable" as SystemSeq
+component "7\nSchemaUpload" as UploadSeq
+component "8\nSchemaPatch" as PatchSeq
+database "9\nPostgreSQL" as Postgres
+component "10\nConfig" as Config
+component "11\nDB handle" as DBHandle
+file "base.sql" as BaseSQL
+file "patches/*.sql" as PatchSQL
+
+Main --> Initializer
+Main --> Context
+Initializer --> Sequence
+Sequence <|.. DBSeq
+Sequence <|.. SystemSeq
+Sequence <|.. UploadSeq
+Sequence <|.. PatchSeq
+DBSeq --> Config
+DBSeq --> DBHandle
+DBSeq --> Postgres
+DBSeq --> Context
+SystemSeq --> Context
+UploadSeq --> Context
+PatchSeq --> Context
+Context --> Config
+Context --> DBHandle
+DBHandle --> Postgres
+UploadSeq --> BaseSQL
+PatchSeq --> PatchSQL
+@enduml

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/charts/flow_diag.puml
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/charts/flow_diag.puml
@@ -18,7 +18,7 @@ DB --> Init: ctx.DB populated
 Init -> System: Execute(2)
 System -> PG: Acquire advisory lock
 System -> PG: CREATE TABLE IF NOT EXISTS basyxsystem
-System -> PG: INSERT v1.0.0 if no row exists
+System -> PG: INSERT schema_version/state if no row exists
 System -> PG: Release advisory lock
 
 Init -> Upload: Execute(3)
@@ -35,12 +35,17 @@ Upload -> PG: Release advisory lock
 
 Init -> Patch: Execute(4)
 Patch -> PG: Acquire advisory lock
-Patch -> PG: Read basyxsystem.database_version
+Patch -> PG: Read basyxsystem.schema_version/state
 
 alt Current version lower than target
     Patch -> PG: Begin transaction
     Patch -> PG: Execute patch SQL
-    Patch -> PG: Commit transaction
+    alt Patch succeeds
+        Patch -> PG: Set state clean
+        Patch -> PG: Commit transaction
+    else Patch fails
+        Patch -> PG: Set state dirty
+    end
 else Current version equal or newer
     Patch --> Init: Skip patch
 end

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/charts/flow_diag.puml
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/charts/flow_diag.puml
@@ -1,0 +1,52 @@
+@startuml
+
+participant "main.go" as Main
+participant "SchemaInitializer" as Init
+participant "DatabaseConnection" as DB
+participant "SystemTable" as System
+participant "SchemaUpload" as Upload
+participant "SchemaPatch" as Patch
+database "PostgreSQL" as PG
+
+Main -> Init: Register sequences
+Main -> Init: Execute()
+
+Init -> DB: Execute(1)
+DB -> PG: Connect and ping
+DB --> Init: ctx.DB populated
+
+Init -> System: Execute(2)
+System -> PG: Acquire advisory lock
+System -> PG: CREATE TABLE IF NOT EXISTS basyxsystem
+System -> PG: INSERT v1.0.0 if no row exists
+System -> PG: Release advisory lock
+
+Init -> Upload: Execute(3)
+Upload -> PG: Acquire advisory lock
+Upload -> PG: Check base schema marker tables
+
+alt Base schema missing
+    Upload -> PG: Execute base.sql
+else Base schema present
+    Upload --> Init: Skip upload
+end
+
+Upload -> PG: Release advisory lock
+
+Init -> Patch: Execute(4)
+Patch -> PG: Acquire advisory lock
+Patch -> PG: Read basyxsystem.database_version
+
+alt Current version lower than target
+    Patch -> PG: Begin transaction
+    Patch -> PG: Execute patch SQL
+    Patch -> PG: Commit transaction
+else Current version equal or newer
+    Patch --> Init: Skip patch
+end
+
+Patch -> PG: Release advisory lock
+
+Init --> Main: Success or error
+
+@enduml

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/custom-sequences.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/custom-sequences.md
@@ -1,0 +1,64 @@
+# Creating Custom Sequences
+
+Custom sequences can be added when the Configuration Service needs a new deterministic startup step.
+
+## Step 1: Implement the Interface
+
+Create a type that implements `Execute(int) (int, error)` and `GetDescription(int) string`.
+
+```go
+package steps
+
+import "fmt"
+
+type ExampleSequence struct {
+    ctx *ExecutionContext
+}
+
+func NewExampleSequence(ctx *ExecutionContext) *ExampleSequence {
+    return &ExampleSequence{ctx: ctx}
+}
+
+func (es *ExampleSequence) Execute(stepIndex int) (int, error) {
+    if es.ctx == nil || es.ctx.DB == nil {
+        return 1, fmt.Errorf("BASYXCFG-EXAMPLE-NODB: database connection is not initialized")
+    }
+
+    // Execute deterministic startup work here.
+
+    return 0, nil
+}
+
+func (es *ExampleSequence) GetDescription(stepIndex int) string {
+    return fmt.Sprintf("[Step %d] Running example sequence", stepIndex)
+}
+```
+
+## Step 2: Register the Sequence
+
+Register the sequence in `cmd/basyxconfigurationservice/main.go` in the required order.
+
+```go
+schemInit.Register(steps.NewDatabaseConnection(execCtx, configPath))
+schemInit.Register(steps.NewSystemTable(execCtx))
+schemInit.Register(steps.NewSchemaUpload(execCtx, databaseSchema))
+schemInit.Register(steps.NewExampleSequence(execCtx))
+```
+
+## Best Practices
+
+- Keep each sequence focused on one responsibility.
+- Return BaSyx-style error codes with the `BASYXCFG` prefix.
+- Validate required context state at the beginning of `Execute`.
+- Use deterministic ordering and avoid hidden side effects.
+- Use PostgreSQL advisory locking for schema-changing operations.
+- Use explicit transactions for operations that must be atomic.
+- Keep sequence functions small enough to remain easy to review.
+
+## Common Pitfalls
+
+- Registering a sequence before its dependencies are available.
+- Updating database schema without versioning the change as a patch.
+- Performing long-running runtime operations in the startup initializer.
+- Adding non-idempotent SQL to restartable initialization paths.
+

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/database-patch-structure.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/database-patch-structure.md
@@ -62,7 +62,8 @@ Each patch must update the first row in `basyxsystem` to the patch target versio
 
 ```sql
 UPDATE basyxsystem
-SET database_version = 'v1.0.2'
+SET schema_version = 'v1.0.2',
+    state = 'clean'
 WHERE identifier = (
   SELECT identifier
   FROM basyxsystem

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/database-patch-structure.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/database-patch-structure.md
@@ -1,0 +1,73 @@
+# Database Patch Structure
+
+## Recommended Folder Structure
+
+```text
+database/
+  base.sql
+  patches/
+    101.sql
+    102.sql
+    110.sql
+```
+
+The Docker image copies the repository `database/` directory into `/app`, resulting in:
+
+```text
+/app/base.sql
+/app/patches/101.sql
+```
+
+## File Naming Convention
+
+Use sortable numeric names that reflect version progression.
+
+Examples:
+
+| File | Target Version |
+| --- | --- |
+| `101.sql` | `v1.0.1` |
+| `102.sql` | `v1.0.2` |
+| `110.sql` | `v1.1.0` |
+
+The current code does not discover patches automatically from filenames. The filename convention is for maintainability and review clarity.
+
+## Ordering Strategy
+
+Register patches in ascending version order. For example:
+
+```go
+schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "101.sql"), "v1.0.1"))
+schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "102.sql"), "v1.0.2"))
+schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "110.sql"), "v1.1.0"))
+```
+
+If the database is already at `v1.0.1`, the `v1.0.1` patch is skipped and later patches can run.
+
+## Versioning Strategy
+
+Patch target versions use semantic versioning in the format:
+
+```text
+vMAJOR.MINOR.PATCH
+```
+
+The comparison also accepts values without the leading `v`, but repository patches should use the `v` prefix consistently.
+
+## Mandatory Version Update
+
+Each patch must update the first row in `basyxsystem` to the patch target version:
+
+```sql
+UPDATE basyxsystem
+SET database_version = 'v1.0.2'
+WHERE identifier = (
+  SELECT identifier
+  FROM basyxsystem
+  ORDER BY identifier ASC
+  LIMIT 1
+);
+```
+
+The `SystemTable` sequence guarantees that the table exists and contains a row before patches run.
+

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/database-patch-structure.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/database-patch-structure.md
@@ -1,48 +1,6 @@
 # Database Patch Structure
 
-## Recommended Folder Structure
-
-```text
-database/
-  base.sql
-  patches/
-    101.sql
-    102.sql
-    110.sql
-```
-
-The Docker image copies the repository `database/` directory into `/app`, resulting in:
-
-```text
-/app/base.sql
-/app/patches/101.sql
-```
-
-## File Naming Convention
-
-Use sortable numeric names that reflect version progression.
-
-Examples:
-
-| File | Target Version |
-| --- | --- |
-| `101.sql` | `v1.0.1` |
-| `102.sql` | `v1.0.2` |
-| `110.sql` | `v1.1.0` |
-
-The current code does not discover patches automatically from filenames. The filename convention is for maintainability and review clarity.
-
-## Ordering Strategy
-
-Register patches in ascending version order. For example:
-
-```go
-schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "101.sql"), "v1.0.1"))
-schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "102.sql"), "v1.0.2"))
-schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "110.sql"), "v1.1.0"))
-```
-
-If the database is already at `v1.0.1`, the `v1.0.1` patch is skipped and later patches can run.
+This page describes how database patch files are organized and named for the BaSyx Configuration Service. The structure keeps fresh installations, upgrades, and release reviews predictable.
 
 ## Versioning Strategy
 
@@ -53,6 +11,50 @@ vMAJOR.MINOR.PATCH
 ```
 
 The comparison also accepts values without the leading `v`, but repository patches should use the `v` prefix consistently.
+
+## Recommended Folder Structure
+
+```text
+database/
+  base.sql
+  patches/
+    1_0_1.sql
+    1_0_2.sql
+    1_1_0.sql
+```
+
+The Docker image copies the repository `database/` directory into `/app`, resulting in:
+
+```text
+/app/base.sql
+/app/patches/1_0_1.sql
+```
+
+## File Naming Convention
+
+Use sortable semantic-version-derived names that reflect version progression.
+
+Examples:
+
+| File | Target Version |
+| --- | --- |
+| `1_0_1.sql` | `v1.0.1` |
+| `1_0_2.sql` | `v1.0.2` |
+| `1_1_0.sql` | `v1.1.0` |
+
+The current code does not discover patches automatically from filenames. The filename convention is for maintainability and review clarity.
+
+## Ordering Strategy
+
+Register patches in ascending version order. For example:
+
+```go
+schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "1_0_1.sql"), "v1.0.1"))
+schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "1_0_2.sql"), "v1.0.2"))
+schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "1_1_0.sql"), "v1.1.0"))
+```
+
+If the database is already at `v1.0.1`, the `v1.0.1` patch is skipped and later patches can run.
 
 ## Mandatory Version Update
 
@@ -70,4 +72,3 @@ WHERE identifier = (
 ```
 
 The `SystemTable` sequence guarantees that the table exists and contains a row before patches run.
-

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/execution-flow.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/execution-flow.md
@@ -25,47 +25,7 @@ These components are described in the [architecture overview](architecture.md).
 
 ## Flow Diagram
 
-```mermaid
-sequenceDiagram
-    participant Main as main.go
-    participant Init as SchemaInitializer
-    participant DB as DatabaseConnection
-    participant System as SystemTable
-    participant Upload as SchemaUpload
-    participant Patch as SchemaPatch
-    participant PG as PostgreSQL
-
-    Main->>Init: Register sequences
-    Main->>Init: Execute()
-    Init->>DB: Execute(1)
-    DB->>PG: Connect and ping
-    DB-->>Init: ctx.DB populated
-    Init->>System: Execute(2)
-    System->>PG: Acquire advisory lock
-    System->>PG: CREATE TABLE IF NOT EXISTS basyxsystem
-    System->>PG: INSERT v1.0.0 if no row exists
-    System->>PG: Release advisory lock
-    Init->>Upload: Execute(3)
-    Upload->>PG: Acquire advisory lock
-    Upload->>PG: Check base schema marker tables
-    alt Base schema missing
-        Upload->>PG: Execute base.sql
-    else Base schema present
-        Upload-->>Init: Skip upload
-    end
-    Upload->>PG: Release advisory lock
-    Init->>Patch: Execute(4)
-    Patch->>PG: Acquire advisory lock
-    Patch->>PG: Read basyxsystem.database_version
-    alt Current version lower than target
-        Patch->>PG: Begin transaction
-        Patch->>PG: Execute patch SQL
-        Patch->>PG: Commit transaction
-    else Current version equal or newer
-        Patch-->>Init: Skip patch
-    end
-    Patch->>PG: Release advisory lock
-    Init-->>Main: Success or error
+```{uml} charts/flow_diag.puml
 ```
 
 ```{hint}

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/execution-flow.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/execution-flow.md
@@ -2,7 +2,7 @@
 
 ## Startup Lifecycle
 
-The service lifecycle is deterministic and short-lived:
+The service lifecycle is deterministic and runs before the BaSyx services start:
 
 1. Parse command-line flags.
 2. Create an empty `ExecutionContext`.
@@ -20,6 +20,8 @@ The service currently registers:
 2. `SystemTable`
 3. `SchemaUpload`
 4. `SchemaPatch` for `101.sql` targeting `v1.0.1`
+
+These components are described in the [architecture overview](architecture.md).
 
 ## Flow Diagram
 
@@ -66,6 +68,10 @@ sequenceDiagram
     Init-->>Main: Success or error
 ```
 
+```{hint}
+The diagram shows the current example with one registered patch path to `v1.0.1`. If multiple patches are registered, the `SchemaPatch` step repeats in registration order.
+```
+
 ## Error Handling
 
 `SchemaInitializer.Execute()` stops on the first sequence error. Errors are wrapped with `BASYXCFG-INIT-EXECSTEP`, including the failed sequence index and status code.
@@ -82,4 +88,3 @@ The main function logs the wrapped error as `BASYXCFG-MAIN-EXECUTE` and exits wi
 `SystemTable`, `SchemaUpload`, and `SchemaPatch` use the same PostgreSQL advisory lock ID. This serializes schema changes across concurrent Configuration Service instances.
 
 The patch sequence acquires the advisory lock before reading the current database version. This prevents two instances from both deciding that a patch must run based on the same old version.
-

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/execution-flow.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/execution-flow.md
@@ -1,0 +1,85 @@
+# Execution Flow
+
+## Startup Lifecycle
+
+The service lifecycle is deterministic and short-lived:
+
+1. Parse command-line flags.
+2. Create an empty `ExecutionContext`.
+3. Create a `SchemaInitializer`.
+4. Register sequences in the intended execution order.
+5. Execute all sequences sequentially.
+6. Close the database handle.
+7. Exit with status `0` on success or status `1` on failure.
+
+## Current Registered Order
+
+The service currently registers:
+
+1. `DatabaseConnection`
+2. `SystemTable`
+3. `SchemaUpload`
+4. `SchemaPatch` for `101.sql` targeting `v1.0.1`
+
+## Flow Diagram
+
+```mermaid
+sequenceDiagram
+    participant Main as main.go
+    participant Init as SchemaInitializer
+    participant DB as DatabaseConnection
+    participant System as SystemTable
+    participant Upload as SchemaUpload
+    participant Patch as SchemaPatch
+    participant PG as PostgreSQL
+
+    Main->>Init: Register sequences
+    Main->>Init: Execute()
+    Init->>DB: Execute(1)
+    DB->>PG: Connect and ping
+    DB-->>Init: ctx.DB populated
+    Init->>System: Execute(2)
+    System->>PG: Acquire advisory lock
+    System->>PG: CREATE TABLE IF NOT EXISTS basyxsystem
+    System->>PG: INSERT v1.0.0 if no row exists
+    System->>PG: Release advisory lock
+    Init->>Upload: Execute(3)
+    Upload->>PG: Acquire advisory lock
+    Upload->>PG: Check base schema marker tables
+    alt Base schema missing
+        Upload->>PG: Execute base.sql
+    else Base schema present
+        Upload-->>Init: Skip upload
+    end
+    Upload->>PG: Release advisory lock
+    Init->>Patch: Execute(4)
+    Patch->>PG: Acquire advisory lock
+    Patch->>PG: Read basyxsystem.database_version
+    alt Current version lower than target
+        Patch->>PG: Begin transaction
+        Patch->>PG: Execute patch SQL
+        Patch->>PG: Commit transaction
+    else Current version equal or newer
+        Patch-->>Init: Skip patch
+    end
+    Patch->>PG: Release advisory lock
+    Init-->>Main: Success or error
+```
+
+## Error Handling
+
+`SchemaInitializer.Execute()` stops on the first sequence error. Errors are wrapped with `BASYXCFG-INIT-EXECSTEP`, including the failed sequence index and status code.
+
+Sequences return:
+
+- `0, nil` on success.
+- Non-zero status and an error on failure.
+
+The main function logs the wrapped error as `BASYXCFG-MAIN-EXECUTE` and exits with status `1`.
+
+## Locking Behavior
+
+`SystemTable`, `SchemaUpload`, and `SchemaPatch` use the same PostgreSQL advisory lock ID. This serializes schema changes across concurrent Configuration Service instances.
+
+The patch sequence acquires the advisory lock before reading the current database version. This prevents two instances from both deciding that a patch must run based on the same old version.
+

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/extensibility.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/extensibility.md
@@ -1,0 +1,69 @@
+# Extensibility Guidelines
+
+## Safe Extension Points
+
+Preferred extension points are:
+
+- New sequence implementations in `internal/basyxconfigurationservice/sequences`.
+- Additional explicit sequence registrations in `cmd/basyxconfigurationservice/main.go`.
+- New SQL patch files in `database/patches`.
+- Additional tests for new sequence behavior.
+
+## Stability Considerations
+
+The Configuration Service runs before other BaSyx services. A failure blocks dependent services from starting, so changes should be conservative and deterministic.
+
+When extending the service:
+
+- Preserve the run-once-and-exit behavior.
+- Avoid background goroutines or server loops unless the service goal changes explicitly.
+- Keep startup work deterministic.
+- Avoid non-idempotent operations in restartable sequences.
+- Keep database patch history immutable.
+
+## Backward Compatibility
+
+Database changes must consider existing installations. If a database may already contain older data, patches should migrate that data safely.
+
+Avoid assumptions that are only true for fresh databases. The service supports fresh initialization and upgrades from an existing version row.
+
+## Idempotency
+
+Initialization steps may be retried by container platforms. Sequences should therefore be safe to run more than once whenever possible.
+
+Use patterns such as:
+
+- `CREATE TABLE IF NOT EXISTS`
+- `ALTER TABLE IF EXISTS ... ADD COLUMN IF NOT EXISTS`
+- `CREATE INDEX IF NOT EXISTS`
+- Version checks before patch execution
+
+## Logging and Observability
+
+Each sequence should provide a clear `GetDescription` result and return errors with stable error codes. This makes deployment logs useful when startup fails.
+
+Recommended error-code format:
+
+```text
+BASYXCFG-COMPONENT-STEP: detailed error
+```
+
+Examples:
+
+- `BASYXCFG-DB-CONNECT`
+- `BASYXCFG-SYSTEM-CREATETABLE`
+- `BASYXCFG-SCHEMA-EXECUTE`
+- `BASYXCFG-PATCH-EXECUTE`
+
+## Testing Recommendations
+
+For sequence changes, add unit tests with SQL expectations where practical. Useful test cases include:
+
+- Missing database handle.
+- Successful execution.
+- SQL execution failure.
+- Skip behavior when initialization is already complete.
+- Patch version comparison behavior.
+
+For database patches, prefer integration testing against PostgreSQL before release because SQL syntax and DDL behavior are database-specific.
+

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/guidelines.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/guidelines.md
@@ -1,5 +1,7 @@
 # Developer Guidelines
 
+This page summarizes the development rules for changing or extending the BaSyx Configuration Service. It focuses on the areas where contributors most often affect runtime behavior: sequence registration, SQL patch handling, compatibility with existing databases, idempotent startup behavior, logging, and tests.
+
 ## Safe Extension Points
 
 Preferred extension points are:

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/guidelines.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/guidelines.md
@@ -1,4 +1,4 @@
-# Extensibility Guidelines
+# Developer Guidelines
 
 ## Safe Extension Points
 
@@ -66,4 +66,3 @@ For sequence changes, add unit tests with SQL expectations where practical. Usef
 - Patch version comparison behavior.
 
 For database patches, prefer integration testing against PostgreSQL before release because SQL syntax and DDL behavior are database-specific.
-

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/index.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/index.md
@@ -1,0 +1,30 @@
+# BaSyx Configuration Service Developer Documentation
+
+This documentation describes the internal architecture and extension points of the BaSyx Configuration Service.
+
+The service is implemented as a small ordered sequence runner. It connects to PostgreSQL, prepares the BaSyx schema-version table, uploads the base schema when needed, and applies explicitly registered SQL patches.
+
+## Documentation
+
+- [Architecture Overview](architecture.md)
+- [Execution Flow](execution-flow.md)
+- [Sequences](sequences.md)
+- [Creating Custom Sequences](custom-sequences.md)
+- [Patches](patches.md)
+- [Database Patch Structure](database-patch-structure.md)
+- [Release Advisor](release-advisor.md)
+- [Extensibility Guidelines](extensibility.md)
+
+```{toctree}
+:hidden:
+:maxdepth: 1
+
+architecture
+execution-flow
+sequences
+custom-sequences
+patches
+database-patch-structure
+release-advisor
+extensibility
+```

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/index.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/index.md
@@ -2,7 +2,7 @@
 
 This documentation describes the internal architecture and extension points of the BaSyx Configuration Service.
 
-The service is implemented as a small ordered sequence runner. It connects to PostgreSQL, prepares the BaSyx schema-version table, uploads the base schema when needed, and applies explicitly registered SQL patches.
+The service is implemented as a small ordered sequence runner. It connects to PostgreSQL, creates and preseeds the BaSyx schema-version table, uploads the base schema if not present, and applies registered SQL patches.
 
 ## Documentation
 
@@ -13,7 +13,7 @@ The service is implemented as a small ordered sequence runner. It connects to Po
 - [Patches](patches.md)
 - [Database Patch Structure](database-patch-structure.md)
 - [Release Advisor](release-advisor.md)
-- [Extensibility Guidelines](extensibility.md)
+- [Developer Guidelines](guidelines.md)
 
 ```{toctree}
 :hidden:
@@ -26,5 +26,5 @@ custom-sequences
 patches
 database-patch-structure
 release-advisor
-extensibility
+guidelines
 ```

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/patches.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/patches.md
@@ -8,7 +8,7 @@ A patch should include:
 
 - A header describing the patch version and purpose.
 - Idempotent schema changes where practical.
-- A final update to `basyxsystem.database_version`.
+- A final update to the schema version stored in `basyxsystem.database_version`.
 
 Example:
 
@@ -51,7 +51,7 @@ Patch files are registered explicitly in `main.go`:
 schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "101.sql"), "v1.0.1"))
 ```
 
-To add a new patch, register it after older patches:
+To add a new patch, register it after older patches. Patch target versions must use semantic versioning:
 
 ```go
 schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "102.sql"), "v1.0.2"))
@@ -67,15 +67,17 @@ Every released patch must include:
 - A database version update to the target version.
 - A version value matching the target version registered in Go.
 
-## Important Patch Disclaimer
+```{warning}
+Existing patches must NEVER be modified after release.
+```
 
-> Existing patches must NEVER be modified after release.
+## Important Patch Disclaimer
 
 Released patches are part of the migration history. Changing an already released patch can break reproducibility because two installations may both claim to have applied the same patch version while having different database structures.
 
 If a released patch contains an issue, create a new patch that corrects it. Do not edit the old patch.
 
-## Why This Rule Matters
+### Why This Rule Matters
 
 Immutable patches provide:
 
@@ -83,4 +85,3 @@ Immutable patches provide:
 - Consistent troubleshooting and support.
 - Deterministic upgrade paths.
 - Clear auditability of database changes.
-

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/patches.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/patches.md
@@ -1,0 +1,86 @@
+# Creating and Managing Patches
+
+Patches are SQL files applied by `SchemaPatch` sequences. They are used for schema changes after the base schema version.
+
+## Patch Structure
+
+A patch should include:
+
+- A header describing the patch version and purpose.
+- Idempotent schema changes where practical.
+- A final update to `basyxsystem.database_version`.
+
+Example:
+
+```sql
+-- ============================================================================
+-- Project        : Eclipse BaSyx
+-- File Type      : SQL Patch Script
+-- Patch Version  : 1.0.2
+-- Description    : Adds example table indexes.
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS ix_example_table_name ON example_table(name);
+
+UPDATE basyxsystem
+SET database_version = 'v1.0.2'
+WHERE identifier = (
+  SELECT identifier
+  FROM basyxsystem
+  ORDER BY identifier ASC
+  LIMIT 1
+);
+```
+
+## Version Handling Requirements
+
+The Go code decides whether to execute a patch by comparing:
+
+- The current database version from `basyxsystem.database_version`.
+- The target version passed to `NewSchemaPatch`.
+
+The patch SQL file is responsible for updating the database version. The Go patch sequence does not update the version after executing the patch.
+
+This means every patch that changes the schema version must include an `UPDATE basyxsystem SET database_version = ...` statement.
+
+## Registering a Patch
+
+Patch files are registered explicitly in `main.go`:
+
+```go
+schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "101.sql"), "v1.0.1"))
+```
+
+To add a new patch, register it after older patches:
+
+```go
+schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "102.sql"), "v1.0.2"))
+schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "110.sql"), "v1.1.0"))
+```
+
+## Mandatory Patch Contents
+
+Every released patch must include:
+
+- SQL changes required for that version.
+- Safe guards such as `IF EXISTS` or `IF NOT EXISTS` where appropriate.
+- A database version update to the target version.
+- A version value matching the target version registered in Go.
+
+## Important Patch Disclaimer
+
+> Existing patches must NEVER be modified after release.
+
+Released patches are part of the migration history. Changing an already released patch can break reproducibility because two installations may both claim to have applied the same patch version while having different database structures.
+
+If a released patch contains an issue, create a new patch that corrects it. Do not edit the old patch.
+
+## Why This Rule Matters
+
+Immutable patches provide:
+
+- Reproducible migrations across environments.
+- Consistent troubleshooting and support.
+- Deterministic upgrade paths.
+- Clear auditability of database changes.
+

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/patches.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/patches.md
@@ -48,14 +48,14 @@ This means every patch that changes the schema version must include an `UPDATE b
 Patch files are registered explicitly in `main.go`:
 
 ```go
-schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "101.sql"), "v1.0.1"))
+schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "1_0_1.sql"), "v1.0.1"))
 ```
 
 To add a new patch, register it after older patches. Patch target versions must use semantic versioning:
 
 ```go
-schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "102.sql"), "v1.0.2"))
-schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "110.sql"), "v1.1.0"))
+schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "1_0_2.sql"), "v1.0.2"))
+schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "1_1_0.sql"), "v1.1.0"))
 ```
 
 ## Mandatory Patch Contents

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/patches.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/patches.md
@@ -8,7 +8,7 @@ A patch should include:
 
 - A header describing the patch version and purpose.
 - Idempotent schema changes where practical.
-- A final update to the schema version stored in `basyxsystem.database_version`.
+- A final update to the schema version and clean state stored in `basyxsystem`.
 
 Example:
 
@@ -23,7 +23,8 @@ Example:
 CREATE INDEX IF NOT EXISTS ix_example_table_name ON example_table(name);
 
 UPDATE basyxsystem
-SET database_version = 'v1.0.2'
+SET schema_version = 'v1.0.2',
+    state = 'clean'
 WHERE identifier = (
   SELECT identifier
   FROM basyxsystem
@@ -36,12 +37,12 @@ WHERE identifier = (
 
 The Go code decides whether to execute a patch by comparing:
 
-- The current database version from `basyxsystem.database_version`.
+- The current schema version from `basyxsystem.schema_version`.
 - The target version passed to `NewSchemaPatch`.
 
 The patch SQL file is responsible for updating the database version. The Go patch sequence does not update the version after executing the patch.
 
-This means every patch that changes the schema version must include an `UPDATE basyxsystem SET database_version = ...` statement.
+This means every patch that changes the schema version must update `basyxsystem.schema_version` and leave `basyxsystem.state` as `clean`.
 
 ## Registering a Patch
 

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/release-advisor.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/release-advisor.md
@@ -56,8 +56,6 @@ Use this checklist whenever a release changes the database schema.
 
 ## Fresh Installations vs Upgrades
 
-Fresh installations and upgrades both need to end at the same database version.
-
 | Scenario | Expected behavior |
 | --- | --- |
 | Fresh database | `SystemTable` creates `basyxsystem` with `v1.0.0`, `SchemaUpload` uploads `base.sql`, then registered patches advance the version. |

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/release-advisor.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/release-advisor.md
@@ -1,0 +1,179 @@
+# Release Advisor
+
+This guide explains how to keep BaSyx core services, database patches, Docker images, examples, and CI checks in sync when releasing changes that affect the database schema.
+
+## Release Principle
+
+The BaSyx Configuration Service owns database initialization and patch execution. Regular BaSyx core services do not migrate the database; they validate that the database version matches the version they expect.
+
+For every schema-affecting release, these parts must move together:
+
+- `database/base.sql`
+- `database/patches/*.sql`
+- Patch registration in `cmd/basyxconfigurationservice/main.go`
+- `common.CURRENT_DATABASE_VERSION` in `internal/common/database.go`
+- Docker images for the Configuration Service and affected BaSyx core services
+- Docker Compose examples and integration-test compose files
+- CI test and release workflows
+
+If one part is updated without the others, deployments can fail at startup or run with an incompatible schema.
+
+## Core Service Synchronization Model
+
+Core services call the common database version validation during startup. The expected version is defined centrally as `common.CURRENT_DATABASE_VERSION`.
+
+```mermaid
+flowchart TD
+    Patch[SQL patch updates basyxsystem.database_version] --> DB[(PostgreSQL)]
+    ConfigSvc[BaSyx Configuration Service] --> Patch
+    CoreVersion[common.CURRENT_DATABASE_VERSION] --> ServiceStartup[Core service startup]
+    ServiceStartup --> DB
+    DB --> Validate{DB version equals expected version?}
+    Validate -->|yes| Run[Service starts]
+    Validate -->|no| Fail[Service fails fast]
+```
+
+The Configuration Service must be able to bring the database to the same version that core services expect. For example, if `CURRENT_DATABASE_VERSION` is `v1.0.2`, the Configuration Service must register and execute patches up to `v1.0.2`.
+
+## Schema Release Checklist
+
+Use this checklist whenever a release changes the database schema.
+
+- Add a new SQL patch file under `database/patches`.
+- Ensure the patch file updates `basyxsystem.database_version` to the new target version.
+- Register the new patch in `cmd/basyxconfigurationservice/main.go` after all older patches.
+- Update `common.CURRENT_DATABASE_VERSION` in `internal/common/database.go` to the new target version.
+- Keep `database/base.sql` aligned with the full schema expected for fresh installations.
+- Do not edit already released patch files.
+- Verify Docker Compose files start `basyx_configuration` before services that validate the database version.
+- Ensure release and snapshot workflows include the Configuration Service image.
+- Run unit tests for `internal/basyxconfigurationservice`.
+- Run representative integration tests for services affected by the schema change.
+
+## Fresh Installations vs Upgrades
+
+Fresh installations and upgrades both need to end at the same database version.
+
+| Scenario | Expected behavior |
+| --- | --- |
+| Fresh database | `SystemTable` creates `basyxsystem` with `v1.0.0`, `SchemaUpload` uploads `base.sql`, then registered patches advance the version. |
+| Existing database at old version | `SchemaUpload` skips the base schema when base tables exist, then newer registered patches run sequentially. |
+| Existing database already current | Base schema upload and already applied patches are skipped. |
+
+Because fresh installations also run patches, `base.sql` and patches must be compatible. A schema change that is included in `base.sql` should still have a safe patch for existing installations, usually using `IF EXISTS` or `IF NOT EXISTS` guards where appropriate.
+
+## Version Alignment Example
+
+When releasing `v1.0.2`:
+
+1. Create `database/patches/102.sql`.
+2. End the patch with:
+
+```sql
+UPDATE basyxsystem
+SET database_version = 'v1.0.2'
+WHERE identifier = (
+  SELECT identifier
+  FROM basyxsystem
+  ORDER BY identifier ASC
+  LIMIT 1
+);
+```
+
+3. Register the patch:
+
+```go
+schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "101.sql"), "v1.0.1"))
+schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "102.sql"), "v1.0.2"))
+```
+
+4. Update the expected service version:
+
+```go
+const (
+    CURRENT_DATABASE_VERSION = "v1.0.2"
+)
+```
+
+5. Build and release both the Configuration Service image and the affected BaSyx core service images from the same commit or release tag.
+
+## Docker Image Release Coordination
+
+The Configuration Service image contains the database SQL files copied from the repository. Therefore, the image version matters for schema releases.
+
+For a release tag, ensure that:
+
+- `eclipsebasyx/basyxconfigurationservice-go` is built from the same tag as the core service images.
+- Core service images contain the matching `CURRENT_DATABASE_VERSION` constant.
+- Examples and deployment manifests use compatible image tags.
+
+Avoid combining a newer core service image with an older Configuration Service image. The core service may expect a database version that the old Configuration Service cannot create.
+
+## Docker Compose Coordination
+
+Any compose file that starts a database-backed BaSyx service should include the Configuration Service as a completed dependency.
+
+Recommended pattern:
+
+```yaml
+services:
+  basyx_configuration:
+    image: eclipsebasyx/basyxconfigurationservice-go:<release-tag>
+    depends_on:
+      db:
+        condition: service_healthy
+
+  submodelrepository:
+    image: eclipsebasyx/submodelrepository-go:<release-tag>
+    depends_on:
+      basyx_configuration:
+        condition: service_completed_successfully
+      db:
+        condition: service_healthy
+```
+
+This prevents core services from starting before schema initialization and patches are complete.
+
+## CI and Release Workflow Checks
+
+Before merging or releasing schema changes, verify:
+
+- The Configuration Service unit tests run in CI.
+- Database-related path filters include `database/**` where relevant.
+- Docker snapshot and release workflows include `basyxconfigurationservice` in their image matrix.
+- Container vulnerability scanning includes the Configuration Service image when image matrices are changed.
+- Integration tests use compose files with `basyx_configuration` dependencies.
+
+Useful local checks include:
+
+```bash
+go test -v ./internal/basyxconfigurationservice/...
+go test ./cmd/basyxconfigurationservice
+go vet ./internal/basyxconfigurationservice/... ./cmd/basyxconfigurationservice
+```
+
+Run affected integration tests when schema changes touch service behavior.
+
+## Common Release Failure Modes
+
+| Failure | Likely cause | Fix |
+| --- | --- | --- |
+| Core service fails with database version mismatch | `CURRENT_DATABASE_VERSION` is newer than the DB version produced by the Configuration Service. | Add/register the missing patch or align image versions. |
+| Patch runs but version remains old | Patch SQL does not update `basyxsystem.database_version`. | Add the mandatory version update to the patch. |
+| Fresh installation differs from upgraded installation | `base.sql` and patch files are not equivalent. | Update `base.sql` and provide a safe patch for existing databases. |
+| Service starts before schema is ready | Compose/Kubernetes startup ordering does not wait for the Configuration Service. | Add dependency on successful Configuration Service completion. |
+| Reproducibility differs between environments | Released patch was modified after use. | Restore immutability and add a corrective follow-up patch. |
+
+## Release Review Questions
+
+Ask these before approving a schema-related release:
+
+- What database version will this release produce?
+- Does `CURRENT_DATABASE_VERSION` match that produced version?
+- Can a fresh database and an upgraded database both reach the same final schema?
+- Are all patches registered in deterministic order?
+- Does every new patch update `basyxsystem.database_version`?
+- Are Docker images for the Configuration Service and core services released together?
+- Do examples and integration tests use the Configuration Service dependency pattern?
+- Have already released patches remained unchanged?
+

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/release-advisor.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/release-advisor.md
@@ -23,7 +23,7 @@ Core services call the common database version validation during startup. The ex
 
 ```mermaid
 flowchart TD
-    Patch[SQL patch updates basyxsystem.database_version] --> DB[(PostgreSQL)]
+    Patch[SQL patch updates basyxsystem.schema_version] --> DB[(PostgreSQL)]
     ConfigSvc[BaSyx Configuration Service] --> Patch
     CoreVersion[common.CURRENT_DATABASE_VERSION] --> ServiceStartup[Core service startup]
     ServiceStartup --> DB
@@ -45,7 +45,7 @@ The Configuration Service version should match the version of the BaSyx service,
 Use this checklist whenever a release changes the database schema.
 
 - Add a new SQL patch file under `database/patches`.
-- Ensure the patch file updates `basyxsystem.database_version` to the new target version.
+- Ensure the patch file updates `basyxsystem.schema_version` to the new target version and leaves `basyxsystem.state` as `clean`.
 - Register the new patch in `cmd/basyxconfigurationservice/main.go` after all older patches.
 - Update `common.CURRENT_DATABASE_VERSION` in `internal/common/database.go` to the new target version.
 - Keep `database/base.sql` aligned with the full schema expected for fresh installations.
@@ -71,7 +71,8 @@ When releasing `v1.0.2`:
 
 ```sql
 UPDATE basyxsystem
-SET database_version = 'v1.0.2'
+SET schema_version = 'v1.0.2',
+    state = 'clean'
 WHERE identifier = (
   SELECT identifier
   FROM basyxsystem

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/release-advisor.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/release-advisor.md
@@ -1,6 +1,6 @@
 # Release Advisor
 
-This guide explains how to keep BaSyx core services, database patches, Docker images, examples, and CI checks in sync when releasing changes that affect the database schema.
+This guide explains how to keep BaSyx core services, database patches, Docker images, and examples in sync when releasing changes that affect the database schema.
 
 ## Release Principle
 
@@ -14,7 +14,6 @@ For every schema-affecting release, these parts must move together:
 - `common.CURRENT_DATABASE_VERSION` in `internal/common/database.go`
 - Docker images for the Configuration Service and affected BaSyx core services
 - Docker Compose examples and integration-test compose files
-- CI test and release workflows
 
 If one part is updated without the others, deployments can fail at startup or run with an incompatible schema.
 
@@ -33,7 +32,13 @@ flowchart TD
     Validate -->|no| Fail[Service fails fast]
 ```
 
+```{hint}
 The Configuration Service must be able to bring the database to the same version that core services expect. For example, if `CURRENT_DATABASE_VERSION` is `v1.0.2`, the Configuration Service must register and execute patches up to `v1.0.2`.
+```
+
+```{warning}
+The Configuration Service version should match the version of the BaSyx service, for example the AAS Repository, so the database version produced during startup is the same version expected by the running service.
+```
 
 ## Schema Release Checklist
 
@@ -46,7 +51,6 @@ Use this checklist whenever a release changes the database schema.
 - Keep `database/base.sql` aligned with the full schema expected for fresh installations.
 - Do not edit already released patch files.
 - Verify Docker Compose files start `basyx_configuration` before services that validate the database version.
-- Ensure release and snapshot workflows include the Configuration Service image.
 - Run unit tests for `internal/basyxconfigurationservice`.
 - Run representative integration tests for services affected by the schema change.
 
@@ -57,16 +61,14 @@ Fresh installations and upgrades both need to end at the same database version.
 | Scenario | Expected behavior |
 | --- | --- |
 | Fresh database | `SystemTable` creates `basyxsystem` with `v1.0.0`, `SchemaUpload` uploads `base.sql`, then registered patches advance the version. |
-| Existing database at old version | `SchemaUpload` skips the base schema when base tables exist, then newer registered patches run sequentially. |
+| Existing database at old version | `SchemaUpload` skips the base schema when base tables exist, then newer registered patches run sequentially (including `SystemTable` version bump to the newest patch version). |
 | Existing database already current | Base schema upload and already applied patches are skipped. |
-
-Because fresh installations also run patches, `base.sql` and patches must be compatible. A schema change that is included in `base.sql` should still have a safe patch for existing installations, usually using `IF EXISTS` or `IF NOT EXISTS` guards where appropriate.
 
 ## Version Alignment Example
 
 When releasing `v1.0.2`:
 
-1. Create `database/patches/102.sql`.
+1. Create [`database/patches/102.sql`](https://github.com/eclipse-basyx/basyx-go-components/tree/main/database/patches).
 2. End the patch with:
 
 ```sql
@@ -80,14 +82,14 @@ WHERE identifier = (
 );
 ```
 
-3. Register the patch:
+3. Register the patch in [`cmd/basyxconfigurationservice/main.go`](https://github.com/eclipse-basyx/basyx-go-components/blob/main/cmd/basyxconfigurationservice/main.go):
 
 ```go
 schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "101.sql"), "v1.0.1"))
 schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "102.sql"), "v1.0.2"))
 ```
 
-4. Update the expected service version:
+4. Update the expected service version in [`internal/common/database.go`](https://github.com/eclipse-basyx/basyx-go-components/blob/main/internal/common/database.go):
 
 ```go
 const (
@@ -95,19 +97,7 @@ const (
 )
 ```
 
-5. Build and release both the Configuration Service image and the affected BaSyx core service images from the same commit or release tag.
-
-## Docker Image Release Coordination
-
-The Configuration Service image contains the database SQL files copied from the repository. Therefore, the image version matters for schema releases.
-
-For a release tag, ensure that:
-
-- `eclipsebasyx/basyxconfigurationservice-go` is built from the same tag as the core service images.
-- Core service images contain the matching `CURRENT_DATABASE_VERSION` constant.
-- Examples and deployment manifests use compatible image tags.
-
-Avoid combining a newer core service image with an older Configuration Service image. The core service may expect a database version that the old Configuration Service cannot create.
+5. Build and release the Configuration Service image and the affected BaSyx core service images with matching versions.
 
 ## Docker Compose Coordination
 
@@ -133,47 +123,3 @@ services:
 ```
 
 This prevents core services from starting before schema initialization and patches are complete.
-
-## CI and Release Workflow Checks
-
-Before merging or releasing schema changes, verify:
-
-- The Configuration Service unit tests run in CI.
-- Database-related path filters include `database/**` where relevant.
-- Docker snapshot and release workflows include `basyxconfigurationservice` in their image matrix.
-- Container vulnerability scanning includes the Configuration Service image when image matrices are changed.
-- Integration tests use compose files with `basyx_configuration` dependencies.
-
-Useful local checks include:
-
-```bash
-go test -v ./internal/basyxconfigurationservice/...
-go test ./cmd/basyxconfigurationservice
-go vet ./internal/basyxconfigurationservice/... ./cmd/basyxconfigurationservice
-```
-
-Run affected integration tests when schema changes touch service behavior.
-
-## Common Release Failure Modes
-
-| Failure | Likely cause | Fix |
-| --- | --- | --- |
-| Core service fails with database version mismatch | `CURRENT_DATABASE_VERSION` is newer than the DB version produced by the Configuration Service. | Add/register the missing patch or align image versions. |
-| Patch runs but version remains old | Patch SQL does not update `basyxsystem.database_version`. | Add the mandatory version update to the patch. |
-| Fresh installation differs from upgraded installation | `base.sql` and patch files are not equivalent. | Update `base.sql` and provide a safe patch for existing databases. |
-| Service starts before schema is ready | Compose/Kubernetes startup ordering does not wait for the Configuration Service. | Add dependency on successful Configuration Service completion. |
-| Reproducibility differs between environments | Released patch was modified after use. | Restore immutability and add a corrective follow-up patch. |
-
-## Release Review Questions
-
-Ask these before approving a schema-related release:
-
-- What database version will this release produce?
-- Does `CURRENT_DATABASE_VERSION` match that produced version?
-- Can a fresh database and an upgraded database both reach the same final schema?
-- Are all patches registered in deterministic order?
-- Does every new patch update `basyxsystem.database_version`?
-- Are Docker images for the Configuration Service and core services released together?
-- Do examples and integration tests use the Configuration Service dependency pattern?
-- Have already released patches remained unchanged?
-

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/sequences.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/sequences.md
@@ -1,0 +1,56 @@
+# Sequences
+
+## What Are Sequences?
+
+A sequence is one executable initialization step. Sequences are small, ordered units of work that implement the common `Sequence` interface:
+
+```go
+type Sequence interface {
+    Execute(int) (int, error)
+    GetDescription(int) string
+}
+```
+
+The integer argument is the one-based sequence index used for logging and error reporting.
+
+## Why Sequences Exist
+
+Sequences keep startup logic modular and deterministic. Each step has a narrow responsibility, such as connecting to the database or applying one patch.
+
+This structure avoids embedding all startup behavior in `main.go` and makes it easier to add new initialization steps without changing the initializer execution logic.
+
+## Relationship Between Sequences and Patches
+
+A patch is represented by a `SchemaPatch` sequence. The sequence owns the decision whether the patch file should run by comparing the current database version with the patch target version.
+
+The patch SQL file owns the actual schema changes and must update `basyxsystem.database_version` itself.
+
+## Ordering Semantics
+
+Sequences run in the exact order in which they are registered:
+
+```go
+schemInit.Register(steps.NewDatabaseConnection(execCtx, configPath))
+schemInit.Register(steps.NewSystemTable(execCtx))
+schemInit.Register(steps.NewSchemaUpload(execCtx, databaseSchema))
+schemInit.Register(steps.NewSchemaPatch(execCtx, filepath.Join(patchBasePath, "101.sql"), "v1.0.1"))
+```
+
+There is no automatic dependency resolver. If a sequence depends on state created by another sequence, it must be registered after that sequence.
+
+## Execution Guarantees
+
+The initializer guarantees:
+
+- Sequential execution in registration order.
+- Stop-on-first-error behavior.
+- Consistent logging before and after each successful sequence.
+
+The initializer does not provide automatic rollback across multiple sequences. Individual sequences must define their own transactional behavior when needed.
+
+## Transaction and Rollback Considerations
+
+`SchemaPatch` executes the patch SQL inside a database transaction. If patch execution fails, the transaction is rolled back.
+
+`SchemaUpload` executes the full base schema SQL through the database handle without an explicit transaction wrapper in Go. The SQL file itself should remain safe and repeatable for initialization scenarios.
+

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/sequences.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/sequences.md
@@ -23,7 +23,7 @@ This structure avoids embedding all startup behavior in `main.go` and makes it e
 
 A patch is represented by a `SchemaPatch` sequence. The sequence owns the decision whether the patch file should run by comparing the current database version with the patch target version.
 
-The patch SQL file owns the actual schema changes and must update `basyxsystem.database_version` itself.
+The patch SQL file owns the actual schema changes and must update `basyxsystem.schema_version` itself.
 
 ## Ordering Semantics
 
@@ -53,4 +53,3 @@ The initializer does not provide automatic rollback across multiple sequences. I
 `SchemaPatch` executes the patch SQL inside a database transaction. If patch execution fails, the transaction is rolled back.
 
 `SchemaUpload` executes the full base schema SQL through the database handle without an explicit transaction wrapper in Go. The SQL file itself should remain safe and repeatable for initialization scenarios.
-

--- a/docs/source/content/developer_documentation/basyx_go/index.md
+++ b/docs/source/content/developer_documentation/basyx_go/index.md
@@ -1,0 +1,12 @@
+# BaSyx Go
+
+This section contains developer documentation for Go-based BaSyx backend components and supporting services.
+
+* [BaSyx Configuration Service](configuration_service/index.md)
+
+```{toctree}
+:hidden:
+:maxdepth: 1
+
+configuration_service/index
+```

--- a/docs/source/content/user_documentation/basyx_components/go/common/configuration.md
+++ b/docs/source/content/user_documentation/basyx_components/go/common/configuration.md
@@ -1,6 +1,6 @@
 # General Configuration
 
-BaSyx Go components use a shared configuration model from `internal/common` and support configuration via YAML files plus environment variables.
+BaSyx Go components use a shared configuration model from `internal/common`. Configuration can be provided through a YAML file and overridden with environment variables.
 
 ## Configuration Source Precedence
 
@@ -10,61 +10,91 @@ The shared configuration loader applies the following precedence:
 2. YAML configuration file
 3. Built-in defaults
 
-Environment variables override values from the YAML file. Nested keys use underscore notation (for example `server.port` -> `SERVER_PORT`).
+Environment variables override YAML values. Nested keys use underscore notation, for example `server.port` becomes `SERVER_PORT`.
 
 ## Common Configuration Sections
 
-These configuration blocks are part of the shared config model and are reused across components:
+These sections are part of the shared configuration model. Components ignore settings that are not relevant to their feature set.
 
-- `server` (host, port, context path, cache settings, verification flags)
-- `postgres` (database connection and pooling)
-- `cors` (allowed origins/methods/headers and credentials)
-- `general` (shared runtime feature flags)
-- `oidc` (trustlist path for issuer validation)
-- `abac` (ABAC enable flag and rule model path)
-- `jws` (private key path for signing use cases)
-- `swagger` (contact metadata for OpenAPI/Swagger UI)
+### `server`
 
-## Security Files (OIDC Trustlist and ABAC Access Rules)
+| Key | Default | Purpose |
+| --- | --- | --- |
+| `host` | `0.0.0.0` | Host used for the HTTP server and generated Swagger server URL. |
+| `port` | `5004` | HTTP server port. |
+| `contextPath` | `""` | Base path for API, Swagger, and health endpoints. |
+| `cacheEnabled` | `false` | Enables descriptor persistence caches where supported. |
+| `strictVerification` | `permissive` | Semantic verification mode: `off`, `permissive`, or `strict`. |
+| `verificationEndpointAvailable` | `true` | Enables the `/verify` endpoint and Swagger entry where supported. |
 
-Components that use the shared OIDC/ABAC security setup may rely on these two file paths:
+### `postgres`
 
-- `oidc.trustlistPath` (default: `config/trustlist.json`)
-- `abac.modelPath` (default: `config/access_rules/access-rules.json`)
+| Key | Default | Purpose |
+| --- | --- | --- |
+| `host` | `db` | PostgreSQL host. |
+| `port` | `5432` | PostgreSQL port. |
+| `user` | `admin` | Database user. |
+| `password` | `admin123` | Database password. |
+| `dbname` | `basyxTestDB` | Database name. |
+| `maxOpenConnections` | `50` | Maximum number of open DB connections. |
+| `maxIdleConnections` | `50` | Maximum number of idle DB connections. |
+| `connMaxLifetimeMinutes` | `5` | Maximum DB connection lifetime in minutes. |
 
-### What they are used for
+### `cors`
 
-- `oidc.trustlistPath`: JSON trustlist of allowed OIDC providers (issuer, audience, scopes)
-- `abac.modelPath`: ABAC access-rules model used for authorization decisions
+| Key | Default | Purpose |
+| --- | --- | --- |
+| `allowedOrigins` | `[]` | Allowed CORS origins. |
+| `allowedMethods` | `[GET, POST, PUT, PATCH, DELETE, OPTIONS]` | Allowed HTTP methods. |
+| `allowedHeaders` | `[]` | Allowed request headers. |
+| `allowCredentials` | `false` | Enables credentialed CORS requests. |
 
-### How paths are configured
+### `oidc` and `abac`
 
-- YAML:
-  - `oidc.trustlistPath`
-  - `abac.modelPath`
-- Environment variables (override YAML):
-  - `OIDC_TRUSTLISTPATH`
-  - `ABAC_MODELPATH`
+| Key | Default | Purpose |
+| --- | --- | --- |
+| `oidc.trustlistPath` | `config/trustlist.json` | JSON trustlist of accepted OIDC providers. |
+| `abac.enabled` | `false` | Enables OIDC authentication and ABAC authorization middleware. |
+| `abac.modelPath` | `config/access_rules/access-rules.json` | ABAC access-rules model. |
 
-### Startup behavior
+If `abac.enabled` is `false`, the shared security setup is skipped. If it is `true`, the trustlist is required and the ABAC model is loaded when `abac.modelPath` is set.
 
-- If `abac.enabled = false`, components using the shared security setup typically skip OIDC/ABAC initialization and do not require these files at startup.
-- If `abac.enabled = true`, the trustlist file is read during startup. The ABAC model file is also read when `abac.modelPath` is set (default: set).
-- Invalid path, unreadable file, or invalid JSON / invalid access model causes startup failure.
+### `general`
 
-### Docker / Container handling
+| Key | Default | Purpose |
+| --- | --- | --- |
+| `enableImplicitCasts` | `true` | Allows implicit casts in ABAC/query expression evaluation. |
+| `enableDescriptorDebug` | `false` | Enables descriptor query debug output. |
+| `discoveryIntegration` | `false` | Enables discovery-specific descriptor behavior; some services set this internally. |
+| `enableCustomMiddlewareHeaderInjection` | `false` | Enables custom claim/header middleware where supported. |
+| `supportsSingularSupplementalSemanticId` | `false` | Accepts singular `supplementalSemanticId` compatibility format. |
+| `aasRegistryIntegration` | `false` | Enables AAS repository to AAS registry synchronization. |
+| `submodelRegistryIntegration` | `false` | Enables Submodel repository to Submodel registry synchronization. |
+| `externalUrl` | `""` | Public base URL used to generate synchronized registry endpoint descriptors. Multiple URLs can be comma-separated. |
+| `uploadMaxSizeBytes` | `134217728` | Maximum upload size for repository/environment upload endpoints. |
+| `aasPreconfigPaths` | `[]` | AAS Environment startup import sources. Supports files or folders with `.aasx`, `.json`, or `.xml` files. |
 
-- Paths are resolved inside the container filesystem.
-- Mount the files (or a directory containing them) into the container and point the config/env vars to the mounted paths.
-- Example mount pattern: `./security_env:/security_env:ro`
+When registry synchronization is enabled, `general.externalUrl` must be set to at least one absolute URL with scheme and host.
 
-## Example YAML (Shared Structure)
+### `jws` and `swagger`
+
+| Key | Default | Purpose |
+| --- | --- | --- |
+| `jws.privateKeyPath` | `""` | RSA private key used by Submodel Repository and AAS Environment signing use cases. |
+| `swagger.contactName` | `Eclipse BaSyx` | Contact name injected into OpenAPI/Swagger docs. |
+| `swagger.contactEmail` | `basyx-dev@eclipse.org` | Contact email injected into OpenAPI/Swagger docs. |
+| `swagger.contactUrl` | `https://basyx.org` | Contact URL injected into OpenAPI/Swagger docs. |
+
+## Example YAML
 
 ```yaml
 server:
   host: 0.0.0.0
   port: 5004
   contextPath: ""
+  cacheEnabled: false
+  strictVerification: permissive
+  verificationEndpointAvailable: true
 
 postgres:
   host: db
@@ -92,6 +122,14 @@ abac:
 general:
   enableImplicitCasts: true
   enableDescriptorDebug: false
+  discoveryIntegration: false
+  enableCustomMiddlewareHeaderInjection: false
+  supportsSingularSupplementalSemanticId: false
+  aasRegistryIntegration: false
+  submodelRegistryIntegration: false
+  externalUrl: ""
+  uploadMaxSizeBytes: 134217728
+  aasPreconfigPaths: []
 
 jws:
   privateKeyPath: ""
@@ -102,7 +140,43 @@ swagger:
   contactUrl: "https://basyx.org"
 ```
 
+## Environment Variables
+
+Use uppercase names with underscores:
+
+```bash
+SERVER_PORT=5004
+SERVER_CONTEXTPATH=/api
+SERVER_STRICTVERIFICATION=permissive
+POSTGRES_HOST=db
+POSTGRES_PORT=5432
+POSTGRES_USER=admin
+POSTGRES_PASSWORD=admin123
+POSTGRES_DBNAME=basyxTestDB
+ABAC_ENABLED=false
+OIDC_TRUSTLISTPATH=config/trustlist.json
+GENERAL_EXTERNALURL=https://example.org/aas
+GENERAL_UPLOADMAXSIZEBYTES=134217728
+```
+
+`GENERAL_AAS_PRECONFIG_PATHS` is parsed as a comma-separated list and overrides `general.aasPreconfigPaths`:
+
+```bash
+GENERAL_AAS_PRECONFIG_PATHS=file:/data/example.aasx,/data/preconfigured-aas
+```
+
+## Security Files
+
+Components that use shared OIDC/ABAC security may rely on these paths:
+
+- `oidc.trustlistPath`
+- `abac.modelPath`
+
+In containers, paths are resolved inside the container filesystem. Mount the files or their parent directory and point the YAML value or environment variable to the mounted path.
+
 ## Notes
 
-- Some components may ignore config blocks that are not relevant to their feature set.
-- Individual component pages should document only component-specific options and behavior; shared options are documented here.
+- The BaSyx Configuration Service mainly uses the `postgres` section.
+- Repository and environment services use `general.uploadMaxSizeBytes` for upload limits.
+- AAS Environment additionally supports `general.aasPreconfigPaths`.
+- AAS Repository, Submodel Repository, and AAS Environment use the registry synchronization settings when enabled.

--- a/docs/source/content/user_documentation/basyx_components/go/configuration_service/capabilities.md
+++ b/docs/source/content/user_documentation/basyx_components/go/configuration_service/capabilities.md
@@ -14,8 +14,6 @@ It currently supports:
 - Serializing schema and patch execution with a PostgreSQL advisory lock.
 - Exiting with a non-zero status code when initialization fails.
 
-The service uses ordered initialization sequences internally. From an integrator perspective, this means startup steps run deterministically in the order registered by the service binary.
-
 ## What the Service Does Not Do
 
 The BaSyx Configuration Service is intentionally narrow in scope.
@@ -29,6 +27,3 @@ It does not provide:
 - Automatic backup or database dump creation.
 - A browser-based administration UI.
 - Dynamic patch discovery from arbitrary folders.
-
-Deployment tooling is still responsible for starting containers, defining dependencies, configuring volumes, and managing persistent PostgreSQL storage.
-

--- a/docs/source/content/user_documentation/basyx_components/go/configuration_service/capabilities.md
+++ b/docs/source/content/user_documentation/basyx_components/go/configuration_service/capabilities.md
@@ -1,0 +1,34 @@
+# Capabilities and Limits
+
+## What the Service Does
+
+The BaSyx Configuration Service performs database initialization tasks required before regular BaSyx services start.
+
+It currently supports:
+
+- Loading database connection settings through the common BaSyx configuration mechanism.
+- Connecting to PostgreSQL using the configured `postgres` settings.
+- Creating and seeding the `basyxsystem` version table when it is missing or empty.
+- Uploading the base SQL schema from `base.sql` when the base schema is not yet present.
+- Applying registered SQL patch files only when the database version is older than the patch target version.
+- Serializing schema and patch execution with a PostgreSQL advisory lock.
+- Exiting with a non-zero status code when initialization fails.
+
+The service uses ordered initialization sequences internally. From an integrator perspective, this means startup steps run deterministically in the order registered by the service binary.
+
+## What the Service Does Not Do
+
+The BaSyx Configuration Service is intentionally narrow in scope.
+
+It does not provide:
+
+- A general-purpose orchestration platform.
+- A workflow engine for business processes.
+- Runtime business process execution.
+- A replacement for Kubernetes, Docker Compose, Helm, or other deployment tooling.
+- Automatic backup or database dump creation.
+- A browser-based administration UI.
+- Dynamic patch discovery from arbitrary folders.
+
+Deployment tooling is still responsible for starting containers, defining dependencies, configuring volumes, and managing persistent PostgreSQL storage.
+

--- a/docs/source/content/user_documentation/basyx_components/go/configuration_service/capabilities.md
+++ b/docs/source/content/user_documentation/basyx_components/go/configuration_service/capabilities.md
@@ -8,9 +8,10 @@ It currently supports:
 
 - Loading database connection settings through the common BaSyx configuration mechanism.
 - Connecting to PostgreSQL using the configured `postgres` settings.
-- Creating and seeding the `basyxsystem` version table when it is missing or empty.
+- Creating and seeding the `basyxsystem` table when it is missing or empty.
 - Uploading the base SQL schema from `base.sql` when the base schema is not yet present.
 - Applying registered SQL patch files only when the database version is older than the patch target version.
+- Tracking the schema version and schema state through `basyxsystem.schema_version` and `basyxsystem.state`.
 - Serializing schema and patch execution with a PostgreSQL advisory lock.
 - Exiting with a non-zero status code when initialization fails.
 

--- a/docs/source/content/user_documentation/basyx_components/go/configuration_service/docker-compose.md
+++ b/docs/source/content/user_documentation/basyx_components/go/configuration_service/docker-compose.md
@@ -1,0 +1,94 @@
+# Docker Compose Integration
+
+In Docker Compose deployments, run the BaSyx Configuration Service after PostgreSQL is healthy and before regular BaSyx services start.
+
+## Minimal Example
+
+```yaml
+services:
+  db:
+    image: postgres:16
+    container_name: postgres_db
+    environment:
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: admin123
+      POSTGRES_DB: basyxTestDB
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U admin -d basyxTestDB"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  basyx_configuration:
+    container_name: basyx_configuration
+    image: eclipsebasyx/basyxconfigurationservice-go:latest
+    environment:
+      POSTGRES_HOST: db
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: admin123
+      POSTGRES_DBNAME: basyxTestDB
+      POSTGRES_MAXOPENCONNECTIONS: 50
+      POSTGRES_MAXIDLECONNECTIONS: 25
+      POSTGRES_CONNMAXLIFETIMEMINUTES: 5
+    depends_on:
+      db:
+        condition: service_healthy
+
+  submodelrepository:
+    image: eclipsebasyx/submodelrepository-go:latest
+    depends_on:
+      basyx_configuration:
+        condition: service_completed_successfully
+      db:
+        condition: service_healthy
+    environment:
+      POSTGRES_HOST: db
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: admin123
+      POSTGRES_DBNAME: basyxTestDB
+
+volumes:
+  postgres_data:
+```
+
+## Startup Ordering
+
+Recommended ordering:
+
+1. PostgreSQL starts.
+2. PostgreSQL health check succeeds.
+3. `basyx_configuration` runs and exits successfully.
+4. BaSyx services start.
+
+Use `condition: service_completed_successfully` for services that depend on the database schema being initialized.
+
+## Persistent Storage
+
+Use persistent PostgreSQL storage for non-temporary deployments. Without persistent storage, the database is recreated whenever the database volume is removed, and the Configuration Service will upload the base schema again.
+
+## Custom Schema and Patch Paths
+
+The container image copies the repository database files into `/app`. By default, the service reads:
+
+- Base schema: `/app/base.sql`
+- Patch directory: `/app/patches`
+
+For local or custom setups, override the command:
+
+```yaml
+basyx_configuration:
+  image: eclipsebasyx/basyxconfigurationservice-go:latest
+  command:
+    - /app/basyxconfigurationservice
+    - -databaseSchema
+    - /custom/base.sql
+    - -customPatchPath
+    - /custom/patches
+  volumes:
+    - ./database:/custom:ro
+```
+

--- a/docs/source/content/user_documentation/basyx_components/go/configuration_service/docker-compose.md
+++ b/docs/source/content/user_documentation/basyx_components/go/configuration_service/docker-compose.md
@@ -39,17 +39,15 @@ services:
 
   submodelrepository:
     image: eclipsebasyx/submodelrepository-go:latest
-    depends_on:
-      basyx_configuration:
-        condition: service_completed_successfully
-      db:
-        condition: service_healthy
     environment:
       POSTGRES_HOST: db
       POSTGRES_PORT: 5432
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DBNAME: basyxTestDB
+    depends_on:
+      basyx_configuration:
+        condition: service_completed_successfully
 
 volumes:
   postgres_data:
@@ -64,11 +62,7 @@ Recommended ordering:
 3. `basyx_configuration` runs and exits successfully.
 4. BaSyx services start.
 
-Use `condition: service_completed_successfully` for services that depend on the database schema being initialized.
-
-## Persistent Storage
-
-Use persistent PostgreSQL storage for non-temporary deployments. Without persistent storage, the database is recreated whenever the database volume is removed, and the Configuration Service will upload the base schema again.
+Use `condition: service_completed_successfully` for services that depend on the database schema being initialized.å
 
 ## Custom Schema and Patch Paths
 

--- a/docs/source/content/user_documentation/basyx_components/go/configuration_service/docker-compose.md
+++ b/docs/source/content/user_documentation/basyx_components/go/configuration_service/docker-compose.md
@@ -2,6 +2,10 @@
 
 In Docker Compose deployments, run the BaSyx Configuration Service after PostgreSQL is healthy and before regular BaSyx services start.
 
+```{warning}
+Use the same BaSyx version or build for `basyxconfigurationservice` and the runtime services.
+```
+
 ## Minimal Example
 
 ```yaml
@@ -62,7 +66,13 @@ Recommended ordering:
 3. `basyx_configuration` runs and exits successfully.
 4. BaSyx services start.
 
-Use `condition: service_completed_successfully` for services that depend on the database schema being initialized.å
+Use `condition: service_completed_successfully` for services that depend on the database schema being initialized.
+
+```{warning}
+Mutable image tags such as `latest` and `SNAPSHOT` can change between restarts. If images are pulled fresh on restart, run `basyx_configuration` before DB-backed runtime services because schema requirements may have changed.
+```
+
+Pin exact image versions or image digests for reproducible deployments.
 
 ## Custom Schema and Patch Paths
 
@@ -85,4 +95,3 @@ basyx_configuration:
   volumes:
     - ./database:/custom:ro
 ```
-

--- a/docs/source/content/user_documentation/basyx_components/go/configuration_service/index.md
+++ b/docs/source/content/user_documentation/basyx_components/go/configuration_service/index.md
@@ -1,0 +1,59 @@
+# BaSyx Configuration Service
+
+The BaSyx Configuration Service is a one-shot startup component for preparing the PostgreSQL database used by BaSyx services. It connects to the configured database, ensures the BaSyx system version table exists, uploads the base database schema when required, and applies registered schema patches in version order.
+
+It is intended to run before the BaSyx services that use the same database. After all registered initialization sequences finish successfully, the process exits.
+
+## Purpose
+
+Multiple BaSyx containers can share one PostgreSQL database. If each service tried to create or migrate the schema independently, startup races and conflicting schema changes could occur. The Configuration Service centralizes that responsibility in one component.
+
+Typical use cases include:
+
+- Initializing a fresh PostgreSQL database for BaSyx services.
+- Applying standardized BaSyx database patches during deployment startup.
+- Serializing schema initialization in Docker Compose or containerized environments.
+- Making service startup depend on a completed database initialization job.
+
+## Existing BaSyx Setups
+
+If you already operate a BaSyx (Go) setup that was created before the BaSyx Configuration Service was introduced, read the [Docker Compose Integration](docker-compose.md) guide before updating your deployment.
+
+Existing setups must be adapted so the Configuration Service runs after PostgreSQL is healthy and before any database-backed BaSyx service starts. This is especially important for deployments that already have persistent PostgreSQL volumes, because the Configuration Service is responsible for checking the schema version and applying required patches before the updated services validate the database.
+
+## User Benefits
+
+The BaSyx Configuration Service makes database startup and upgrades safer and easier to operate.
+
+Key benefits include:
+
+- **Safer updates**: Database schema changes are applied centrally before regular BaSyx services start, reducing the risk of competing containers modifying the schema at the same time.
+- **Reduced risk of data loss**: Patches are versioned and executed only when required. This helps avoid accidental repeated migrations and makes upgrade behavior more predictable.
+- **Clear database versioning**: The current schema version is stored in the `basyxsystem` table. BaSyx services can verify that the database version matches the version they expect before serving requests.
+- **Fail-fast protection**: If the database schema is missing, outdated, or incompatible, services fail during startup instead of running against an unsafe database state.
+- **Traceable errors**: Startup failures include stable BaSyx error codes such as `BASYXCFG-DB-CONNECT`, `BASYXCFG-SCHEMA-EXECUTE`, and `BASYXCFG-PATCH-EXECUTE`, making troubleshooting easier in container logs and CI pipelines.
+- **Repeatable deployments**: The same initialization flow can be used for local development, Docker Compose examples, CI environments, and containerized deployments.
+- **Simpler service containers**: Regular BaSyx services no longer need to own schema initialization. They can focus on their runtime responsibilities and rely on a prepared database.
+- **Predictable startup ordering**: Deployment tooling can wait for the Configuration Service to complete successfully before starting dependent services.
+- **Improved auditability**: Schema changes are represented as explicit SQL patch files, making it easier to understand which database changes belong to which release.
+
+## Documentation
+
+- [Capabilities and Limits](capabilities.md)
+- [When to Use the Service](when-to-use.md)
+- [Basic Usage](usage.md)
+- [Docker Compose Integration](docker-compose.md)
+- [Kubernetes Job Integration](kubernetes-job.md)
+- [Operational Considerations](operations.md)
+
+```{toctree}
+:hidden:
+:maxdepth: 1
+
+capabilities
+when-to-use
+usage
+docker-compose
+kubernetes-job
+operations
+```

--- a/docs/source/content/user_documentation/basyx_components/go/configuration_service/index.md
+++ b/docs/source/content/user_documentation/basyx_components/go/configuration_service/index.md
@@ -15,12 +15,6 @@ Typical use cases include:
 - Serializing schema initialization in Docker Compose or containerized environments.
 - Making service startup depend on a completed database initialization job.
 
-## Existing BaSyx Setups
-
-If you already operate a BaSyx (Go) setup that was created before the BaSyx Configuration Service was introduced, read the [Docker Compose Integration](docker-compose.md) guide before updating your deployment.
-
-Existing setups must be adapted so the Configuration Service runs after PostgreSQL is healthy and before any database-backed BaSyx service starts. This is especially important for deployments that already have persistent PostgreSQL volumes, because the Configuration Service is responsible for checking the schema version and applying required patches before the updated services validate the database.
-
 ## User Benefits
 
 The BaSyx Configuration Service makes database startup and upgrades safer and easier to operate.
@@ -45,6 +39,12 @@ Key benefits include:
 - [Docker Compose Integration](docker-compose.md)
 - [Kubernetes Job Integration](kubernetes-job.md)
 - [Operational Considerations](operations.md)
+
+```{warning}
+This note is only relevant for users with BaSyx Go deployments created before v1.0.0. If you already operate such a setup, read the [Docker Compose Integration](docker-compose.md) guide before updating your deployment.
+
+Existing pre-v1.0.0 setups must be adapted so the Configuration Service runs after PostgreSQL is healthy and before any database-backed BaSyx service starts. This is especially important for deployments with persistent PostgreSQL volumes, because the Configuration Service checks the schema version and applies required patches before updated services validate the database.
+```
 
 ```{toctree}
 :hidden:

--- a/docs/source/content/user_documentation/basyx_components/go/configuration_service/index.md
+++ b/docs/source/content/user_documentation/basyx_components/go/configuration_service/index.md
@@ -1,6 +1,6 @@
 # BaSyx Configuration Service
 
-The BaSyx Configuration Service is a one-shot startup component for preparing the PostgreSQL database used by BaSyx services. It connects to the configured database, ensures the BaSyx system version table exists, uploads the base database schema when required, and applies registered schema patches in version order.
+The BaSyx Configuration Service is a one-shot startup component for preparing the PostgreSQL database used by BaSyx services. It connects to the configured database, ensures the BaSyx system table exists, uploads the base database schema when required, and applies registered schema patches in version order.
 
 It is intended to run before the BaSyx services that use the same database. After all registered initialization sequences finish successfully, the process exits.
 
@@ -23,7 +23,7 @@ Key benefits include:
 
 - **Safer updates**: Database schema changes are applied centrally before regular BaSyx services start, reducing the risk of competing containers modifying the schema at the same time.
 - **Reduced risk of data loss**: Patches are versioned and executed only when required. This helps avoid accidental repeated migrations and makes upgrade behavior more predictable.
-- **Clear database versioning**: The current schema version is stored in the `basyxsystem` table. BaSyx services can verify that the database version matches the version they expect before serving requests.
+- **Clear database state**: The current schema version and schema state are stored in the `basyxsystem` table. BaSyx services can verify that the database is compatible and clean before serving requests.
 - **Fail-fast protection**: If the database schema is missing, outdated, or incompatible, services fail during startup instead of running against an unsafe database state.
 - **Traceable errors**: Startup failures include stable BaSyx error codes such as `BASYXCFG-DB-CONNECT`, `BASYXCFG-SCHEMA-EXECUTE`, and `BASYXCFG-PATCH-EXECUTE`, making troubleshooting easier in container logs and CI pipelines.
 - **Repeatable deployments**: The same initialization flow can be used for local development, Docker Compose examples, CI environments, and containerized deployments.

--- a/docs/source/content/user_documentation/basyx_components/go/configuration_service/kubernetes-job.md
+++ b/docs/source/content/user_documentation/basyx_components/go/configuration_service/kubernetes-job.md
@@ -1,0 +1,77 @@
+# Kubernetes Job Integration
+
+The BaSyx Configuration Service can be run as a Kubernetes `Job`. This fits the service model well because the service runs once, prepares the database, and exits after successful initialization.
+
+Use a Kubernetes Job when BaSyx services run in a Kubernetes cluster and the PostgreSQL database must be initialized or patched before application pods start.
+
+## Barebone Job Example
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: basyx-configuration
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app: basyx-configuration
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: basyx-configuration
+          image: eclipsebasyx/basyxconfigurationservice-go:latest
+          env:
+            - name: POSTGRES_HOST
+              value: postgres
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_USER
+              value: admin
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: password
+            - name: POSTGRES_DBNAME
+              value: basyx
+            - name: POSTGRES_MAXOPENCONNECTIONS
+              value: "50"
+            - name: POSTGRES_MAXIDLECONNECTIONS
+              value: "25"
+            - name: POSTGRES_CONNMAXLIFETIMEMINUTES
+              value: "5"
+```
+
+## Secret Example
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-credentials
+type: Opaque
+stringData:
+  password: admin123
+```
+
+## Startup Recommendation
+
+Regular BaSyx workloads should start only after the Configuration Service Job completed successfully.
+
+Common approaches include:
+
+- Running the Job as part of a deployment pipeline before applying BaSyx service manifests.
+- Using Helm hooks to run the Job before installing or upgrading BaSyx services.
+- Using an init container or external deployment controller to wait for the Job completion before starting dependent services.
+
+## Operational Notes
+
+- Use `restartPolicy: OnFailure` so Kubernetes retries the pod if initialization fails.
+- Use `backoffLimit` to control how many retries Kubernetes should attempt.
+- Store database credentials in a Kubernetes `Secret` instead of plain environment variables.
+- Use a fixed image tag for production deployments instead of `latest`.
+- Ensure PostgreSQL is reachable and ready before the Job runs.
+- Check Job logs when initialization fails; errors include BaSyx error codes for troubleshooting.
+

--- a/docs/source/content/user_documentation/basyx_components/go/configuration_service/kubernetes-job.md
+++ b/docs/source/content/user_documentation/basyx_components/go/configuration_service/kubernetes-job.md
@@ -71,7 +71,8 @@ Common approaches include:
 - Use `restartPolicy: OnFailure` so Kubernetes retries the pod if initialization fails.
 - Use `backoffLimit` to control how many retries Kubernetes should attempt.
 - Store database credentials in a Kubernetes `Secret` instead of plain environment variables.
-- Use a fixed image tag for production deployments instead of `latest`.
+- Use the same BaSyx version or build for `basyxconfigurationservice` and the runtime services.
+- Avoid mutable image tags such as `latest` and `SNAPSHOT` for reproducible deployments. Pin exact image versions or image digests where possible.
+- If mutable-tag images are pulled fresh on restart, run the Configuration Service Job before DB-backed runtime workloads.
 - Ensure PostgreSQL is reachable and ready before the Job runs.
 - Check Job logs when initialization fails; errors include BaSyx error codes for troubleshooting.
-

--- a/docs/source/content/user_documentation/basyx_components/go/configuration_service/operations.md
+++ b/docs/source/content/user_documentation/basyx_components/go/configuration_service/operations.md
@@ -1,0 +1,48 @@
+# Operational Considerations
+
+## Logging
+
+The service logs each sequence before execution and logs completion status. Errors include BaSyx-style error codes such as `BASYXCFG-DB-CONNECT`, `BASYXCFG-SCHEMA-EXECUTE`, or `BASYXCFG-PATCH-EXECUTE`.
+
+Example startup logs:
+
+```text
+[Step 1] Connecting to Database
+[Step 1] Database connection established
+[Step 2] Initializing system table
+[Step 3] Uploading SQL schema
+[Step 4] Applying schema patch v1.0.1 (/app/patches/101.sql)
+BaSyx configuration completed successfully
+```
+
+## Failure Behavior
+
+If a sequence fails, the service stops immediately and exits with a non-zero status code. Dependent containers should not start when Docker Compose uses `service_completed_successfully`.
+
+Common failure categories include:
+
+- Database connection failure.
+- Missing or unreadable schema or patch files.
+- SQL execution errors.
+- Invalid or unreadable database version information.
+
+## Idempotency Expectations
+
+The base schema uses idempotent SQL where possible, such as `CREATE TABLE IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS`.
+
+Patch files should also be safe to run in controlled deployment scenarios. The service checks the database version before running a patch, but the patch author is still responsible for writing safe SQL and updating the database version within the patch file.
+
+## Versioning Concept
+
+The database version is stored in the `basyxsystem` table. The Configuration Service creates this table if it is missing and assumes version `v1.0.0` for newly initialized or empty system tables.
+
+Regular BaSyx services validate the database version during startup. If the database version does not match the expected service version, the service fails fast instead of running against an incompatible schema.
+
+## Restart Behavior
+
+The Configuration Service can be restarted. On restart:
+
+- The system table step is idempotent.
+- The base schema upload is skipped when core base schema tables are already present.
+- Already applied patches are skipped when the database version is equal to or newer than the patch target version.
+

--- a/docs/source/content/user_documentation/basyx_components/go/configuration_service/operations.md
+++ b/docs/source/content/user_documentation/basyx_components/go/configuration_service/operations.md
@@ -19,12 +19,20 @@ BaSyx configuration completed successfully
 
 If a sequence fails, the service stops immediately and exits with a non-zero status code. Dependent containers should not start when Docker Compose uses `service_completed_successfully`.
 
+If an error occurs during schema patch execution, the database is marked as `dirty` in `basyxsystem.state`. DB-backed BaSyx services check this state during startup and refuse to start while the database is dirty.
+
 Common failure categories include:
 
 - Database connection failure.
 - Missing or unreadable schema or patch files.
 - SQL execution errors.
-- Invalid or unreadable database version information.
+- Invalid or unreadable schema version or state information.
+
+### Dirty Schema State
+
+`basyxsystem.state` can be `clean` or `dirty`. Successful schema initialization and patching leaves the database state as `clean`.
+
+If a BaSyx service fails with `DB-CHECKVER-DIRTYSTATE`, the database schema was marked dirty because a previous schema patch did not complete successfully. Stop DB-backed BaSyx runtime services, run the matching `basyxconfigurationservice` version against the database, verify it exits successfully, and then restart the runtime services.
 
 ## Idempotency Expectations
 
@@ -34,9 +42,13 @@ Patch files should also be safe to run in controlled deployment scenarios. The s
 
 ## Versioning Concept
 
-The database version is stored in the `basyxsystem` table. The Configuration Service creates this table if it is missing and assumes version `v1.0.0` for newly initialized or empty system tables.
+The database schema version is stored in `basyxsystem.schema_version`. The schema state is stored in `basyxsystem.state`.
 
-Regular BaSyx services validate the database version during startup. If the database version does not match the expected service version, the service fails fast instead of running against an incompatible schema.
+Regular BaSyx services validate both values during startup. If the schema version does not match the expected service version, or if the state is `dirty`, the service fails fast instead of running against an unsafe schema.
+
+```{warning}
+Use the same BaSyx version or build for `basyxconfigurationservice` and the DB-backed runtime services. A newer runtime service may require schema changes that an older Configuration Service image cannot apply.
+```
 
 ## Restart Behavior
 
@@ -44,5 +56,4 @@ The Configuration Service can be restarted. On restart:
 
 - The system table step is idempotent.
 - The base schema upload is skipped when core base schema tables are already present.
-- Already applied patches are skipped when the database version is equal to or newer than the patch target version.
-
+- Already applied patches are skipped when the schema version is equal to or newer than the patch target version.

--- a/docs/source/content/user_documentation/basyx_components/go/configuration_service/usage.md
+++ b/docs/source/content/user_documentation/basyx_components/go/configuration_service/usage.md
@@ -2,15 +2,6 @@
 
 The BaSyx Configuration Service is designed as a run-once startup job. It executes its registered initialization sequences and then exits.
 
-## Startup Flow
-
-1. Load the configured PostgreSQL connection settings.
-2. Connect to PostgreSQL.
-3. Ensure the `basyxsystem` table exists and contains an initial version row.
-4. Upload the base schema when the base schema tables are not present.
-5. Apply registered schema patches if the database version is older than the patch target version.
-6. Exit successfully or fail with a non-zero exit code.
-
 ## Command-Line Options
 
 ```{hint}

--- a/docs/source/content/user_documentation/basyx_components/go/configuration_service/usage.md
+++ b/docs/source/content/user_documentation/basyx_components/go/configuration_service/usage.md
@@ -1,0 +1,67 @@
+# Basic Usage
+
+The BaSyx Configuration Service is designed as a run-once startup job. It executes its registered initialization sequences and then exits.
+
+## Startup Flow
+
+1. Load the configured PostgreSQL connection settings.
+2. Connect to PostgreSQL.
+3. Ensure the `basyxsystem` table exists and contains an initial version row.
+4. Upload the base schema when the base schema tables are not present.
+5. Apply registered schema patches if the database version is older than the patch target version.
+6. Exit successfully or fail with a non-zero exit code.
+
+## Command-Line Options
+
+The service binary supports these options:
+
+```bash
+/app/basyxconfigurationservice \
+  -config /app/config.yaml \
+  -databaseSchema /app/base.sql \
+  -customPatchPath /app/patches
+```
+
+| Option | Purpose | Default |
+| --- | --- | --- |
+| `-config` | Path to the BaSyx configuration file. | Empty path, using common config loading behavior. |
+| `-databaseSchema` | Path to the base schema SQL file or a directory containing `base.sql`. | `/app/base.sql` |
+| `-customPatchPath` | Directory containing registered patch files. | `/app/patches` |
+
+## Configuration Example
+
+The service uses the common BaSyx `postgres` configuration section.
+
+```yaml
+postgres:
+  host: db
+  port: 5432
+  user: admin
+  password: admin123
+  dbname: basyxTestDB
+  maxOpenConnections: 50
+  maxIdleConnections: 25
+  connMaxLifetimeMinutes: 5
+```
+
+Environment variables can also be used in the same style as other BaSyx services, for example:
+
+```bash
+POSTGRES_HOST=db
+POSTGRES_PORT=5432
+POSTGRES_USER=admin
+POSTGRES_PASSWORD=admin123
+POSTGRES_DBNAME=basyxTestDB
+POSTGRES_MAXOPENCONNECTIONS=50
+POSTGRES_MAXIDLECONNECTIONS=25
+POSTGRES_CONNMAXLIFETIMEMINUTES=5
+```
+
+## Patch Execution
+
+Patches are registered by the service implementation. The current service registers `101.sql` with target database version `v1.0.1`.
+
+A patch is executed only if the current value in `basyxsystem.database_version` is lower than the registered target version. The patch SQL file itself must update the database version after successfully applying its changes.
+
+See the developer documentation for details about creating new patches.
+

--- a/docs/source/content/user_documentation/basyx_components/go/configuration_service/usage.md
+++ b/docs/source/content/user_documentation/basyx_components/go/configuration_service/usage.md
@@ -54,8 +54,8 @@ POSTGRES_CONNMAXLIFETIMEMINUTES=5
 
 ## Patch Execution
 
-Patches are registered by the service implementation. The current service registers `101.sql` with target database version `v1.0.1`.
+Patches are registered by the service implementation. The current service registers `101.sql` with target schema version `v1.0.1`.
 
-A patch is executed only if the current value in `basyxsystem.database_version` is lower than the registered target version. The patch SQL file itself must update the database version after successfully applying its changes.
+A patch is executed only if the current value in `basyxsystem.schema_version` is lower than the registered target version. Successful initialization and patching leaves `basyxsystem.state` as `clean`.
 
 See the developer documentation for details about creating new patches.

--- a/docs/source/content/user_documentation/basyx_components/go/configuration_service/usage.md
+++ b/docs/source/content/user_documentation/basyx_components/go/configuration_service/usage.md
@@ -13,6 +13,10 @@ The BaSyx Configuration Service is designed as a run-once startup job. It execut
 
 ## Command-Line Options
 
+```{hint}
+These command-line options are only relevant when the service is not run as part of a Docker container.
+```
+
 The service binary supports these options:
 
 ```bash
@@ -64,4 +68,3 @@ Patches are registered by the service implementation. The current service regist
 A patch is executed only if the current value in `basyxsystem.database_version` is lower than the registered target version. The patch SQL file itself must update the database version after successfully applying its changes.
 
 See the developer documentation for details about creating new patches.
-

--- a/docs/source/content/user_documentation/basyx_components/go/configuration_service/when-to-use.md
+++ b/docs/source/content/user_documentation/basyx_components/go/configuration_service/when-to-use.md
@@ -1,5 +1,7 @@
 # When to Start the Service
 
+**TL;DR:** Essentially, every time a BaSyx Go setup is run.
+
 For BaSyx deployments that use the shared PostgreSQL database schema, the BaSyx Configuration Service is a required startup component. It prepares and updates the database schema before regular BaSyx services start.
 
 Regular BaSyx services validate the database version during startup. If the Configuration Service has not initialized or updated the database first, those services can fail fast because the schema version is missing, outdated, or incompatible.
@@ -11,8 +13,6 @@ Start the BaSyx Configuration Service in these situations:
 - **Before the first start of BaSyx components**: On a fresh database, the service creates the system version table, uploads the base schema, and applies registered patches.
 - **Before starting BaSyx services after an update**: When a new BaSyx version introduces database patches, run the Configuration Service first so the database reaches the version expected by the updated services.
 - **Before restarting services against a recreated database**: If the PostgreSQL volume was removed or the database was recreated, run the Configuration Service before any BaSyx service starts.
-- **During automated deployment startup**: In Docker Compose, CI, or containerized deployments, run it as a startup job after PostgreSQL is healthy and before dependent BaSyx services are started.
-- **When rolling out standardized schema changes**: Patches are applied sequentially and only when the stored database version is older than the patch target version.
 
 ## Recommended Startup Order
 
@@ -35,4 +35,3 @@ This makes it suitable for both fresh installations and upgrades.
 ## When It Does Not Apply
 
 The Configuration Service is not relevant only for deployments that do not use the BaSyx PostgreSQL schema at all. For BaSyx services running with PostgreSQL persistence, it should be treated as part of the required startup process.
-

--- a/docs/source/content/user_documentation/basyx_components/go/configuration_service/when-to-use.md
+++ b/docs/source/content/user_documentation/basyx_components/go/configuration_service/when-to-use.md
@@ -1,0 +1,38 @@
+# When to Start the Service
+
+For BaSyx deployments that use the shared PostgreSQL database schema, the BaSyx Configuration Service is a required startup component. It prepares and updates the database schema before regular BaSyx services start.
+
+Regular BaSyx services validate the database version during startup. If the Configuration Service has not initialized or updated the database first, those services can fail fast because the schema version is missing, outdated, or incompatible.
+
+## Required Startup Points
+
+Start the BaSyx Configuration Service in these situations:
+
+- **Before the first start of BaSyx components**: On a fresh database, the service creates the system version table, uploads the base schema, and applies registered patches.
+- **Before starting BaSyx services after an update**: When a new BaSyx version introduces database patches, run the Configuration Service first so the database reaches the version expected by the updated services.
+- **Before restarting services against a recreated database**: If the PostgreSQL volume was removed or the database was recreated, run the Configuration Service before any BaSyx service starts.
+- **During automated deployment startup**: In Docker Compose, CI, or containerized deployments, run it as a startup job after PostgreSQL is healthy and before dependent BaSyx services are started.
+- **When rolling out standardized schema changes**: Patches are applied sequentially and only when the stored database version is older than the patch target version.
+
+## Recommended Startup Order
+
+Use this order for database-backed BaSyx deployments:
+
+1. Start PostgreSQL.
+2. Wait until PostgreSQL is healthy.
+3. Start the BaSyx Configuration Service.
+4. Wait until the Configuration Service exits successfully.
+5. Start the regular BaSyx services.
+
+In Docker Compose, dependent services should use `service_completed_successfully` for the Configuration Service dependency.
+
+## Existing Databases
+
+The Configuration Service should also be part of deployments with existing databases. It detects already initialized schemas and skips work that is not required. Registered patches are executed only when the current database version is older than the patch target version.
+
+This makes it suitable for both fresh installations and upgrades.
+
+## When It Does Not Apply
+
+The Configuration Service is not relevant only for deployments that do not use the BaSyx PostgreSQL schema at all. For BaSyx services running with PostgreSQL persistence, it should be treated as part of the required startup process.
+

--- a/docs/source/content/user_documentation/basyx_components/go/index.md
+++ b/docs/source/content/user_documentation/basyx_components/go/index.md
@@ -12,6 +12,7 @@ BaSyx Go provides Go-based BaSyx backend components and shared libraries for run
 * [Digital Twin Registry](digital_twin_registry/index)
 * [Submodel Repository](submodel_repository/index)
 * [Registry of Infrastructures](registry_of_infrastructures/index)
+* [Configuration Service](configuration_service/index)
 
 ```{toctree}
 :hidden:
@@ -24,4 +25,5 @@ submodel_registry/index
 digital_twin_registry/index
 submodel_repository/index
 registry_of_infrastructures/index
+configuration_service/index
 ```

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -95,6 +95,7 @@ content/user_documentation/metamodel/index
 * [Contributing](./content/developer_documentation/contributing.md)
 * [BaSyx Java Version 1](./content/developer_documentation/basyx_java_v1/index.md)
 * [BaSyx Java Version 2](./content/developer_documentation/basyx_java_v2/index.md)
+* [BaSyx Go](./content/developer_documentation/basyx_go/index.md)
 * [BaSyx Python SDK](./content/developer_documentation/basyx_python_sdk/index.md)
 * [BaSyx AAS Web UI](./content/developer_documentation/basyx_web_ui/index.md)
 
@@ -106,6 +107,7 @@ content/user_documentation/metamodel/index
 content/developer_documentation/contributing
 content/developer_documentation/basyx_java_v1/index
 content/developer_documentation/basyx_java_v2/index
+content/developer_documentation/basyx_go/index
 content/developer_documentation/basyx_python_sdk/index
 content/developer_documentation/basyx_web_ui/index
 


### PR DESCRIPTION
## Summary

- Add BaSyx Configuration Service user documentation under the existing BaSyx Go component docs
- Add BaSyx Go developer documentation section with Configuration Service internals

## Details

The new documentation covers:

- Configuration Service purpose, capabilities, usage, Docker Compose, Kubernetes Job setup, and operational notes
- Developer-facing architecture, execution flow, sequences, custom sequence extension, patch handling, release guidance, and extensibility
- Main docs navigation updates for both user and developer documentation

## Validation

- Verified all referenced toctree targets exist
- Ran `git diff --check`

## Issue

related to https://github.com/eclipse-basyx/basyx-go-components/issues/308