### PR TITLE
Fixes problem with incorrect chart

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -2,14 +2,6 @@
 html[data-theme="dark"],
 [data-theme="dark"] {
     --pst-color-background: #1e1e1e;
-    --pst-color-on-background: #d4d4d4;
-    --pst-color-surface: #252526;
-    --pst-color-on-surface: #d4d4d4;
-    --pst-color-border: #3c3c3c;
-    --pst-color-text-base: #d4d4d4;
-    --pst-color-text-muted: #9da1a6;
-    --bs-body-bg: #1e1e1e;
-    --bs-body-color: #d4d4d4;
 }
 
 /* Table styles with only outer border and rounded corners */

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -1,3 +1,17 @@
+/* Global dark mode palette: closer to VS Code Dark+ and less close to pure black. */
+html[data-theme="dark"],
+[data-theme="dark"] {
+    --pst-color-background: #1e1e1e;
+    --pst-color-on-background: #d4d4d4;
+    --pst-color-surface: #252526;
+    --pst-color-on-surface: #d4d4d4;
+    --pst-color-border: #3c3c3c;
+    --pst-color-text-base: #d4d4d4;
+    --pst-color-text-muted: #9da1a6;
+    --bs-body-bg: #1e1e1e;
+    --bs-body-color: #d4d4d4;
+}
+
 /* Table styles with only outer border and rounded corners */
 table {
     border-spacing: 0;

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/charts/release_advisor_sync_model.puml
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/charts/release_advisor_sync_model.puml
@@ -1,0 +1,20 @@
+@startuml
+
+participant "BaSyx Configuration Service" as ConfigSvc
+participant "SQL patch" as Patch
+database "PostgreSQL" as DB
+participant "Core service startup" as Startup
+participant "common.CURRENT_DATABASE_VERSION" as CoreVersion
+
+ConfigSvc -> Patch: Execute registered patch
+Patch -> DB: Update basyxsystem.schema_version
+CoreVersion -> Startup: Expected database version
+Startup -> DB: Validate schema version
+
+alt DB version equals expected version
+    Startup -> Startup: Service starts
+else DB version differs
+    Startup -> Startup: Service fails fast
+end
+
+@enduml

--- a/docs/source/content/developer_documentation/basyx_go/configuration_service/release-advisor.md
+++ b/docs/source/content/developer_documentation/basyx_go/configuration_service/release-advisor.md
@@ -21,15 +21,7 @@ If one part is updated without the others, deployments can fail at startup or ru
 
 Core services call the common database version validation during startup. The expected version is defined centrally as `common.CURRENT_DATABASE_VERSION`.
 
-```mermaid
-flowchart TD
-    Patch[SQL patch updates basyxsystem.schema_version] --> DB[(PostgreSQL)]
-    ConfigSvc[BaSyx Configuration Service] --> Patch
-    CoreVersion[common.CURRENT_DATABASE_VERSION] --> ServiceStartup[Core service startup]
-    ServiceStartup --> DB
-    DB --> Validate{DB version equals expected version?}
-    Validate -->|yes| Run[Service starts]
-    Validate -->|no| Fail[Service fails fast]
+```{uml} charts/release_advisor_sync_model.puml
 ```
 
 ```{hint}


### PR DESCRIPTION
This pull request updates the documentation for the BaSyx Go Configuration Service to improve clarity and visual consistency. The main changes include replacing a Mermaid diagram with a PlantUML diagram for describing the release advisor sync model, adding the corresponding PlantUML file, and introducing a global dark mode color palette for the documentation site.

**Documentation diagram improvements:**

* Replaced the Mermaid diagram in `release-advisor.md` with a reference to a new PlantUML diagram for better maintainability and consistency.
* Added a new PlantUML file `charts/release_advisor_sync_model.puml` that visually describes the release advisor sync model for the configuration service.

**Documentation site appearance:**

* Added a global dark mode palette to `custom.css`, making the documentation site visually closer to VS Code Dark+ and improving readability in dark mode.