### PR TITLE
Adds Supply Chain Security documentation

### DIFF
--- a/docs/source/content/user_documentation/basyx_components/charts/supply_chain_artifacts.puml
+++ b/docs/source/content/user_documentation/basyx_components/charts/supply_chain_artifacts.puml
@@ -1,0 +1,59 @@
+@startuml
+top to bottom direction
+skinparam shadowing false
+skinparam componentStyle rectangle
+skinparam defaultTextAlignment center
+skinparam linetype polyline
+skinparam nodesep 20
+skinparam ranksep 25
+
+actor "User / Operator" as user
+
+rectangle "Eclipse BaSyx source repository\nrelease tag or snapshot branch" as buildContext
+rectangle "GitHub Actions\nrelease workflow" as workflow
+
+artifact "Published image digest\nimage@sha256:..." as digest
+
+package "Evidence attached to the image" as attached {
+  artifact "Cosign signature\nwho signed this digest" as signature
+  artifact "Cosign provenance attestation\nhow this digest was built" as cosignProvenance
+  artifact "Cosign SBOM attestation\nwhat software is included" as cosignSbom
+  artifact "BuildKit OCI attestations\nprovenance + SBOM" as buildkitAttestations
+}
+
+package "Release evidence files" as release {
+  artifact "SPDX SBOM\n*.spdx.json" as spdx
+  artifact "CycloneDX SBOM\n*.cdx.json" as cdx
+  artifact "Metadata JSON\ntraceability details" as metadata
+}
+
+rectangle "Consumer checks" as checks {
+  rectangle "Deploy by immutable digest" as deploy
+  rectangle "Verify signature and attestations\nwith expected workflow identity\nand OIDC issuer" as verify
+  rectangle "Archive SBOMs and metadata" as archive
+}
+
+buildContext -down-> workflow
+workflow -down-> digest : build and publish
+digest -down-> attached : signatures and\nattestations
+attached -down-> release : downloadable\nrelease files
+release -down-> checks
+
+signature -[hidden]down-> cosignProvenance
+cosignProvenance -[hidden]down-> cosignSbom
+cosignSbom -[hidden]down-> buildkitAttestations
+
+spdx -[hidden]down-> cdx
+cdx -[hidden]down-> metadata
+
+deploy -[hidden]down-> verify
+verify -[hidden]down-> archive
+
+user -up-> checks
+
+note right of digest
+The digest is the stable deployment target.
+Tags can move; digests identify one artifact.
+end note
+
+@enduml

--- a/docs/source/content/user_documentation/basyx_components/go/index.md
+++ b/docs/source/content/user_documentation/basyx_components/go/index.md
@@ -13,6 +13,7 @@ BaSyx Go provides Go-based BaSyx backend components and shared libraries for run
 * [Submodel Repository](submodel_repository/index)
 * [Registry of Infrastructures](registry_of_infrastructures/index)
 * [Configuration Service](configuration_service/index)
+* [Supply Chain Security](supply_chain_security)
 
 ```{toctree}
 :hidden:
@@ -26,4 +27,5 @@ digital_twin_registry/index
 submodel_repository/index
 registry_of_infrastructures/index
 configuration_service/index
+supply_chain_security
 ```

--- a/docs/source/content/user_documentation/basyx_components/go/supply_chain_security.md
+++ b/docs/source/content/user_documentation/basyx_components/go/supply_chain_security.md
@@ -1,0 +1,217 @@
+# Supply Chain Security
+
+BaSyx Go container images are published with supply-chain metadata that helps users verify where an image came from, how it was built, and which software components it contains.
+
+Use this page when you need to:
+
+- Deploy BaSyx Go images by immutable digest.
+- Verify that a release or snapshot image was signed by the expected Eclipse BaSyx GitHub Actions workflow.
+- Inspect or archive provenance and SBOM evidence.
+- Understand the release artifacts attached to GitHub Releases.
+
+For the general concepts behind these checks, see the [BaSyx supply chain security overview](../supply_chain_security.md).
+
+## What Is Produced
+
+For each BaSyx Go service image, the release pipeline produces:
+
+- Multi-architecture OCI images published to Docker Hub.
+- Sigstore Cosign keyless signatures on immutable image digests.
+- BuildKit OCI attestations for provenance and SBOM data.
+- Cosign-signed provenance attestations.
+- Cosign-signed SBOM attestations using the SPDX predicate type.
+- Exported release SBOM assets in SPDX JSON and CycloneDX JSON formats.
+- Per-service metadata JSON.
+- A release supply-chain manifest JSON.
+- OCI image labels for traceability, including source repository, commit SHA, and version.
+
+The pipeline also verifies the Syft installer by using Cosign-signed checksum manifests before generating exported SBOM files.
+
+## Supported Images
+
+The same verification model applies to BaSyx Go service images such as:
+
+- `eclipsebasyx/aasregistry-go`
+- `eclipsebasyx/submodelregistry-go`
+- `eclipsebasyx/digitaltwinregistry-go`
+- `eclipsebasyx/submodelrepository-go`
+- Additional BaSyx Go service images published by the `basyx-go-components` repository.
+
+Replace the image name in the examples below with the service image you deploy.
+
+## Trust Model
+
+BaSyx Go images are signed by GitHub Actions keyless identity for the `eclipse-basyx/basyx-go-components` repository. Verification should check both the certificate identity and the OIDC issuer.
+
+Expected certificate identity for releases:
+
+```text
+https://github.com/eclipse-basyx/basyx-go-components/.github/workflows/docker-release.yml@refs/tags/<tag>
+```
+
+Expected certificate identity for snapshots:
+
+```text
+https://github.com/eclipse-basyx/basyx-go-components/.github/workflows/docker-snapshot.yml@refs/heads/main
+```
+
+Expected OIDC issuer:
+
+```text
+https://token.actions.githubusercontent.com
+```
+
+```{important}
+Verify by digest, not by tag. A tag such as `latest` or `v1.2.3` can be moved by a registry operation. A digest reference such as `image@sha256:<digest>` identifies the exact image that was signed.
+```
+
+## Verify Image Signatures
+
+Install [Cosign](https://docs.sigstore.dev/cosign/installation/) and verify the immutable image digest.
+
+```bash
+IMAGE="eclipsebasyx/aasregistry-go@sha256:<digest>"
+IDENTITY="https://github.com/eclipse-basyx/basyx-go-components/.github/workflows/docker-release.yml@refs/tags/<tag>"
+
+cosign verify \
+  --certificate-identity "$IDENTITY" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  "$IMAGE"
+```
+
+For snapshots, use the snapshot workflow identity:
+
+```bash
+IDENTITY="https://github.com/eclipse-basyx/basyx-go-components/.github/workflows/docker-snapshot.yml@refs/heads/main"
+```
+
+Successful verification means the digest was signed by the expected GitHub Actions workflow identity. It does not mean the image is free of vulnerabilities or suitable for every deployment context.
+
+## Verify Provenance Attestations
+
+The release workflow creates explicit Cosign provenance attestations from BuildKit provenance data and verifies them with identity constraints.
+
+Use the provenance predicate type that appears in the BuildKit output. Common values are:
+
+- `https://slsa.dev/provenance/v1`
+- `https://slsa.dev/provenance/v0.2`
+
+```bash
+IMAGE="eclipsebasyx/aasregistry-go@sha256:<digest>"
+IDENTITY="https://github.com/eclipse-basyx/basyx-go-components/.github/workflows/docker-release.yml@refs/tags/<tag>"
+PROVENANCE_TYPE="https://slsa.dev/provenance/v1"
+
+cosign verify-attestation \
+  --type "$PROVENANCE_TYPE" \
+  --certificate-identity "$IDENTITY" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  "$IMAGE"
+```
+
+Provenance is useful when you need evidence about the repository, workflow, and source revision used to build the image.
+
+## Verify SBOM Attestations
+
+The workflow also creates explicit Cosign SBOM attestations from BuildKit SBOM data.
+
+```bash
+IMAGE="eclipsebasyx/aasregistry-go@sha256:<digest>"
+IDENTITY="https://github.com/eclipse-basyx/basyx-go-components/.github/workflows/docker-release.yml@refs/tags/<tag>"
+
+cosign verify-attestation \
+  --type "https://spdx.dev/Document" \
+  --certificate-identity "$IDENTITY" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  "$IMAGE"
+```
+
+SBOM attestations are useful for automated checks. Downloadable SBOM files from GitHub Releases are useful for audit records and downstream vulnerability management.
+
+## Verify BuildKit OCI Attestations Exist
+
+The workflow attaches provenance and SBOM as BuildKit OCI attestations to the OCI image index.
+
+```bash
+IMAGE="eclipsebasyx/aasregistry-go@sha256:<digest>"
+
+docker buildx imagetools inspect "$IMAGE" --raw | jq \
+  '.manifests[] | select(.annotations["vnd.docker.reference.type"] == "attestation-manifest")'
+```
+
+If this command returns attestation manifests, the OCI index has attached BuildKit attestations.
+
+You can inspect BuildKit provenance and SBOM content with:
+
+```bash
+IMAGE="eclipsebasyx/aasregistry-go@sha256:<digest>"
+
+docker buildx imagetools inspect "$IMAGE" --format '{{ json (index .Provenance "linux/amd64").SLSA }}' | jq .
+docker buildx imagetools inspect "$IMAGE" --format '{{ json (index .SBOM "linux/amd64").SPDX }}' | jq .
+```
+
+If your Docker or Buildx version does not expose per-platform maps, try:
+
+```bash
+docker buildx imagetools inspect "$IMAGE" --format '{{ json .Provenance.SLSA }}' | jq .
+docker buildx imagetools inspect "$IMAGE" --format '{{ json .SBOM.SPDX }}' | jq .
+```
+
+## Retrieve Release SBOM Assets
+
+GitHub Releases include per-service exported SBOM files:
+
+- `service-version.spdx.json`
+- `service-version.cdx.json`
+
+The release may also include per-service metadata JSON and a release supply-chain manifest JSON. Store these files with your deployment records if your organization needs audit evidence.
+
+## Versioning and Tagging Implications
+
+Release workflows parse the semantic version from the Git tag.
+
+- Stable releases receive `major.minor.patch`, `major.minor`, `major`, and `latest` tags.
+- Pre-releases keep explicit pre-release tags only.
+- Metadata labels include the source repository, commit SHA, and version.
+- Signatures and attestations are anchored to the immutable digest, not to the tag.
+
+For production, prefer release tags and digest-pinned deployments. Snapshot artifacts remain non-stable by definition and are better suited for testing.
+
+## Vulnerability Scanning
+
+The repository provides a report-only Trivy workflow for continuous visibility.
+
+- Repository filesystem scans cover source and dependency manifests.
+- Container image scans build and scan service images on scheduled runs.
+- Findings are uploaded as SARIF when permitted.
+- The current mode does not fail builds.
+
+Downstream users should still scan the exact image digest they deploy. Vulnerability impact depends on the deployment configuration, exposed interfaces, reachable code paths, and available mitigations.
+
+## Migration Guidance
+
+If you currently deploy by mutable tag:
+
+1. Resolve the tag to a digest.
+2. Update deployment manifests to use `image@sha256:<digest>`.
+3. Verify the image signature with the expected workflow identity.
+4. Download or archive release SBOM assets when compliance evidence is required.
+5. Adjust automation that consumes release assets to match the current per-service SBOM file names.
+
+## Current SLSA Posture
+
+The BaSyx Go release model aligns with common SLSA build-integrity practices:
+
+- GitHub Actions OIDC-based signing identity.
+- Immutable digest-first signing.
+- Provenance attestation and verification in CI.
+- SBOM generation and signed SBOM attestations.
+- Least-privilege workflow permissions.
+- Immutable action pinning in workflows.
+
+This posture improves traceability and tamper evidence. It does not replace dependency review, runtime hardening, vulnerability response, or environment-specific risk assessment.
+
+## Vulnerability Disclosure
+
+For vulnerability reporting and disclosure policy, use the Eclipse BaSyx global security policy:
+
+- [eclipse-basyx/.github SECURITY.md](https://github.com/eclipse-basyx/.github/blob/main/SECURITY.md)

--- a/docs/source/content/user_documentation/basyx_components/index.md
+++ b/docs/source/content/user_documentation/basyx_components/index.md
@@ -6,6 +6,7 @@
 * [AAS Web UI](./web_ui/index.md)
 * [Databridge Component](./databridge/index.md)
 * [Test Orchestrator](./testorchestrator/index.md)
+* [Supply Chain Security](./supply_chain_security.md)
 
 ```{toctree}
 :hidden:
@@ -17,4 +18,5 @@ go/index
 web_ui/index
 databridge/index
 testorchestrator/index
+supply_chain_security
 ```

--- a/docs/source/content/user_documentation/basyx_components/supply_chain_security.md
+++ b/docs/source/content/user_documentation/basyx_components/supply_chain_security.md
@@ -1,0 +1,92 @@
+# Supply Chain Security
+
+Supply chain security describes how users can gain confidence that a released BaSyx container image really comes from the expected Eclipse BaSyx repository, was built by the expected CI workflow, and has machine-readable evidence describing how it was produced.
+
+This is different from runtime security. Runtime security controls who can access a running component. Supply chain security helps you decide whether an artifact is trustworthy before you deploy it.
+
+The following diagram shows the main artifacts and evidence users interact with. The image digest is the central deployment artifact; signatures, attestations, SBOMs, and metadata provide the evidence around it.
+
+```{uml} charts/supply_chain_artifacts.puml
+```
+
+## Why This Matters
+
+Industrial and digital-twin deployments often become part of long-lived production environments. Pulling an image by name alone, for example `eclipsebasyx/aas-gui:latest`, is convenient, but it does not provide much evidence about what exact artifact was deployed or how it was built.
+
+Supply chain metadata helps with:
+
+| Benefit | What it means for users |
+| --- | --- |
+| Integrity | Verify that the immutable image digest was signed by the expected project workflow. |
+| Traceability | Connect an image back to a repository, commit, workflow, and release version. |
+| Auditability | Keep SBOM and provenance files as evidence for compliance and internal reviews. |
+| Vulnerability management | Identify the packages and base images inside an artifact so scanners and downstream teams can reason about exposure. |
+| Reproducible operations | Deploy by digest so production systems do not silently move when a mutable tag is updated. |
+
+## What BaSyx Release Pipelines Provide
+
+BaSyx Go and the BaSyx AAS Web UI publish container artifacts with open supply-chain standards. Depending on the component, release pipelines provide:
+
+| Artifact or capability | Why it is useful |
+| --- | --- |
+| Multi-architecture OCI container images | Support deployment on different CPU architectures. |
+| Sigstore Cosign keyless signatures | Prove that an immutable image digest was signed by the expected workflow identity. |
+| BuildKit OCI attestations | Attach build-time provenance and SBOM data to the OCI image index. |
+| Cosign-signed provenance attestations | Provide independently verifiable evidence about how the image was built. |
+| Cosign-signed SBOM attestations | Provide independently verifiable package inventory evidence for the image digest. |
+| Exported SPDX and CycloneDX SBOM files | Give downstream users downloadable evidence for audits, inventories, and vulnerability tooling. |
+| Metadata files | Make release artifacts easier to trace back to source and build context. |
+| Vulnerability scanning workflows | Provide continuous visibility for maintainers. |
+
+The component-specific pages explain the exact workflow identities, image names, and verification commands:
+
+- [BaSyx Go supply chain security](./go/supply_chain_security.md)
+- [BaSyx AAS Web UI supply chain security](./web_ui/features/supply_chain_security.md)
+
+## Recommended Consumer Practice
+
+For production or compliance-relevant deployments:
+
+1. Select a release version instead of a snapshot whenever possible.
+2. Resolve the image tag to an immutable digest.
+3. Deploy using `image@sha256:<digest>` instead of a mutable tag.
+4. Verify the Cosign signature against the expected GitHub Actions workflow identity.
+5. Verify provenance and SBOM attestations when your organization requires build evidence.
+6. Store the release SBOM files together with your deployment or release records.
+7. Run vulnerability scans in your own environment because risk depends on your deployment context, network exposure, configuration, and compensating controls.
+
+```{note}
+Snapshot artifacts are useful for testing, but they are not stable release evidence. Prefer tagged releases for production deployments and compliance records.
+```
+
+## Key Terms
+
+**Image digest**
+: A cryptographic identifier such as `sha256:...` that points to one immutable image artifact. Tags can move; digests do not.
+
+**Cosign signature**
+: A Sigstore signature proving that a specific image digest was signed by a specific identity. BaSyx uses keyless signing, so trust is anchored in GitHub Actions OIDC identity rather than a long-lived private signing key.
+
+**OIDC issuer**
+: The identity provider that issued the signing certificate. For GitHub Actions this is `https://token.actions.githubusercontent.com`.
+
+**Certificate identity**
+: The workflow identity that signed the artifact. Verification should check this value so that a signature from an unrelated workflow or repository is not accepted.
+
+**Provenance**
+: Build metadata describing where and how an artifact was produced, such as repository, workflow, source revision, and build platform.
+
+**SBOM**
+: A Software Bill of Materials. It lists software packages and dependencies contained in the artifact so users can perform vulnerability, license, and inventory checks.
+
+**BuildKit OCI attestation**
+: Provenance or SBOM metadata attached to the OCI image index by Docker BuildKit.
+
+**Cosign-signed attestation**
+: An in-toto attestation signed with Cosign and attached to the image digest. It can be verified independently with identity constraints.
+
+## Vulnerability Disclosure
+
+For vulnerability reporting and disclosure policy, use the Eclipse BaSyx global security policy:
+
+- [eclipse-basyx/.github SECURITY.md](https://github.com/eclipse-basyx/.github/blob/main/SECURITY.md)

--- a/docs/source/content/user_documentation/basyx_components/web_ui/features/security.md
+++ b/docs/source/content/user_documentation/basyx_components/web_ui/features/security.md
@@ -10,6 +10,10 @@ The BaSyx AAS Web UI supports comprehensive security mechanisms for authenticati
 
 Security in the AAS ecosystem is based on the standardized [AAS Security Specification (IDTA-01004)](https://industrialdigitaltwin.io/aas-specifications/IDTA-01004/v3.0.1/index.html), which defines authentication, authorization, and access control mechanisms for Asset Administration Shells. The Web UI implements these security concepts, supporting both **Role-Based Access Control (RBAC)** and **Attribute-Based Access Control (ABAC)** as defined in the AAS Part 4 specification.
 
+```{seealso}
+This page describes runtime access security. To verify published container images, signatures, provenance, and SBOMs before deployment, see [Supply Chain Security](./supply_chain_security.md).
+```
+
 ```{note}
 From the Web UI perspective, it doesn't matter whether your backend implements RBAC or ABAC—both are supported transparently through standard OAuth2/OIDC token-based authentication. The backend services determine which access control model is applied.
 ```

--- a/docs/source/content/user_documentation/basyx_components/web_ui/features/supply_chain_security.md
+++ b/docs/source/content/user_documentation/basyx_components/web_ui/features/supply_chain_security.md
@@ -1,0 +1,217 @@
+# Supply Chain Security
+
+The BaSyx AAS Web UI release pipeline for `eclipsebasyx/aas-gui` follows open supply-chain standards and publishes verifiable evidence for release artifacts.
+
+Use this page when you need to:
+
+- Verify that an AAS Web UI image was signed by the expected Eclipse BaSyx GitHub Actions workflow.
+- Inspect provenance and SBOM attestations.
+- Download SBOM release assets for audit, compliance, or downstream vulnerability management.
+- Understand the difference between release evidence and runtime Web UI security.
+
+For the general concepts behind these checks, see the [BaSyx supply chain security overview](../../supply_chain_security.md).
+
+## What the Release Workflow Produces
+
+For each published release, the AAS Web UI release workflow produces:
+
+- Multi-architecture Docker images for `linux/amd64`, `linux/arm64`, and `linux/arm/v7`.
+- Docker BuildKit OCI attestations attached to the image index.
+- BuildKit provenance with `provenance: mode=max`.
+- BuildKit SBOM output with `sbom: true`.
+- Sigstore Cosign keyless signature on the immutable image digest.
+- Cosign-signed provenance attestations from BuildKit provenance predicates.
+- Cosign-signed SBOM attestations using the `https://spdx.dev/Document` predicate type.
+- Exported SPDX JSON SBOM files named `aas-gui-<version>.spdx.json`.
+- Exported CycloneDX JSON SBOM files named `aas-gui-<version>.cdx.json`.
+- `release-image-metadata.json`.
+- SBOM uploads as GitHub Actions artifacts for build-time evidence.
+- SBOM uploads as GitHub Release assets for versioned downloadable evidence.
+
+The workflow verifies the Syft bootstrap by checking a signed checksum file and certificate identity constraints before verifying the downloaded archive hash.
+
+## Trust Model
+
+AAS Web UI images are signed by GitHub Actions keyless identity for the `eclipse-basyx/basyx-aas-web-ui` repository. Verification should check both the certificate identity and the OIDC issuer.
+
+Expected certificate identity for releases:
+
+```text
+https://github.com/eclipse-basyx/basyx-aas-web-ui/.github/workflows/docker-release-ui.yml@refs/tags/<tag>
+```
+
+Expected certificate identity for snapshots:
+
+```text
+https://github.com/eclipse-basyx/basyx-aas-web-ui/.github/workflows/docker-prerelease-ui.yml@refs/heads/main
+```
+
+Expected OIDC issuer:
+
+```text
+https://token.actions.githubusercontent.com
+```
+
+```{important}
+Verify by digest, not by tag. A digest reference such as `eclipsebasyx/aas-gui@sha256:<digest>` identifies the exact artifact that was signed.
+```
+
+## Verify Image Signature
+
+Install [Cosign](https://docs.sigstore.dev/cosign/installation/) and verify the immutable image digest.
+
+```bash
+IMAGE="eclipsebasyx/aas-gui@sha256:<digest>"
+IDENTITY="https://github.com/eclipse-basyx/basyx-aas-web-ui/.github/workflows/docker-release-ui.yml@refs/tags/<tag>"
+
+cosign verify \
+  --certificate-identity "$IDENTITY" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  "$IMAGE"
+```
+
+For snapshots, use the snapshot workflow identity:
+
+```bash
+IDENTITY="https://github.com/eclipse-basyx/basyx-aas-web-ui/.github/workflows/docker-prerelease-ui.yml@refs/heads/main"
+```
+
+Successful verification means the digest was signed by the expected GitHub Actions workflow identity. It does not mean the image is free of vulnerabilities or that the runtime configuration is secure.
+
+## Verify Provenance Attestations
+
+The workflow creates explicit Cosign provenance attestations from BuildKit provenance data.
+
+Use the provenance predicate type detected from BuildKit output. Common values are:
+
+- `https://slsa.dev/provenance/v1`
+- `https://slsa.dev/provenance/v0.2`
+
+```bash
+IMAGE="eclipsebasyx/aas-gui@sha256:<digest>"
+IDENTITY="https://github.com/eclipse-basyx/basyx-aas-web-ui/.github/workflows/docker-release-ui.yml@refs/tags/<tag>"
+PROVENANCE_TYPE="https://slsa.dev/provenance/v1"
+
+cosign verify-attestation \
+  --type "$PROVENANCE_TYPE" \
+  --certificate-identity "$IDENTITY" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  "$IMAGE"
+```
+
+Provenance helps you confirm the build identity and retain evidence about how the artifact was produced.
+
+## Verify SBOM Attestations
+
+```bash
+IMAGE="eclipsebasyx/aas-gui@sha256:<digest>"
+IDENTITY="https://github.com/eclipse-basyx/basyx-aas-web-ui/.github/workflows/docker-release-ui.yml@refs/tags/<tag>"
+
+cosign verify-attestation \
+  --type "https://spdx.dev/Document" \
+  --certificate-identity "$IDENTITY" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  "$IMAGE"
+```
+
+SBOM attestations are useful for automated policy checks. Downloadable SBOM release assets are useful for audit records, inventory systems, and downstream vulnerability management.
+
+## Verify BuildKit OCI Attestations Exist
+
+The workflow attaches provenance and SBOM as BuildKit OCI attestations.
+
+```bash
+IMAGE="eclipsebasyx/aas-gui@sha256:<digest>"
+
+docker buildx imagetools inspect "$IMAGE" --raw | jq \
+  '.manifests[] | select(.annotations["vnd.docker.reference.type"] == "attestation-manifest")'
+```
+
+If this command returns attestation manifests, the OCI index has attached BuildKit attestations.
+
+## Inspect BuildKit Provenance and SBOM Payloads
+
+```bash
+IMAGE="eclipsebasyx/aas-gui@sha256:<digest>"
+
+docker buildx imagetools inspect "$IMAGE" --format '{{ json (index .Provenance "linux/amd64").SLSA }}' | jq .
+docker buildx imagetools inspect "$IMAGE" --format '{{ json (index .SBOM "linux/amd64").SPDX }}' | jq .
+```
+
+If your Docker or Buildx version does not expose per-platform maps, try:
+
+```bash
+docker buildx imagetools inspect "$IMAGE" --format '{{ json .Provenance.SLSA }}' | jq .
+docker buildx imagetools inspect "$IMAGE" --format '{{ json .SBOM.SPDX }}' | jq .
+```
+
+## Download SBOM Release Assets
+
+Each release includes:
+
+- `aas-gui-<version>.spdx.json`
+- `aas-gui-<version>.cdx.json`
+- `release-image-metadata.json`
+
+Download these files from the GitHub Release page for the tag you deploy. Store them together with your deployment records if your organization needs release evidence.
+
+## Artifact Types and What They Mean
+
+**Signed image digest**
+: Cryptographic evidence that the immutable image digest was signed by the expected workflow identity.
+
+**BuildKit OCI attestations**
+: OCI-attached provenance and SBOM data produced at image build time.
+
+**Cosign-signed provenance attestation**
+: Signed in-toto evidence about the build process and source context.
+
+**Cosign-signed SBOM attestation**
+: Signed in-toto SBOM evidence attached to the image digest.
+
+**GitHub Actions SBOM artifact**
+: CI-run artifact retained for build evidence and troubleshooting.
+
+**GitHub Release SBOM assets**
+: Versioned SBOM exports intended for downstream consumers and compliance records.
+
+## Vulnerability Scanning
+
+Vulnerability scanning is handled in a dedicated workflow:
+
+- `.github/workflows/vuln-scan.yml`
+- Trivy repository filesystem scan for pull requests, pushes, schedules, and manual runs.
+- Trivy container image scan for pushes, schedules, and manual runs.
+- Report-only behavior.
+- SARIF upload to GitHub code scanning where permitted.
+
+Downstream users should still scan the exact image digest they deploy. Vulnerability impact depends on the deployed configuration, reachable components, exposed interfaces, and compensating controls.
+
+## Practical Deployment Implications
+
+For production or compliance-relevant deployments:
+
+1. Prefer release images over snapshots.
+2. Resolve the image tag to an immutable digest.
+3. Deploy `eclipsebasyx/aas-gui@sha256:<digest>` instead of only `eclipsebasyx/aas-gui:<tag>`.
+4. Verify the signature with the expected release workflow identity.
+5. Verify provenance and SBOM attestations when your policy requires build evidence.
+6. Download and archive the SPDX or CycloneDX SBOM release assets.
+7. Configure runtime Web UI authentication separately. Supply chain verification does not replace OAuth2, OIDC, HTTPS, or backend authorization.
+
+## Attestation Verification Model
+
+The release workflows verify:
+
+- Cosign image signatures.
+- BuildKit OCI attestation presence and readability.
+- Cosign provenance attestations.
+- Cosign SBOM attestations.
+
+This provides tamper evidence and traceability for published artifacts. It does not replace vulnerability response, secure runtime configuration, or environment-specific risk assessment.
+
+## Vulnerability Disclosure
+
+For vulnerability reporting and disclosure policy, use the Eclipse BaSyx global security policy:
+
+- [eclipse-basyx/.github SECURITY.md](https://github.com/eclipse-basyx/.github/blob/main/SECURITY.md)

--- a/docs/source/content/user_documentation/basyx_components/web_ui/index.md
+++ b/docs/source/content/user_documentation/basyx_components/web_ui/index.md
@@ -21,6 +21,7 @@ name: web_ui
 * [Data Synchronization](./features/data_sync.md)
 * [Docker Configuration](./features/docker_config.md)
 * [Security](./features/security.md)
+* [Supply Chain Security](./features/supply_chain_security.md)
 * [Corporate Design](./features/corporate_design.md)
 * [Mobile Support](./features/mobile_support.md)
 * [Plugins](./features/plugin_mechanism.md)
@@ -36,6 +37,7 @@ features/configuration
 features/data_sync
 features/docker_config
 features/security
+features/supply_chain_security
 features/corporate_design
 features/mobile_support
 features/plugin_mechanism


### PR DESCRIPTION
This pull request introduces comprehensive user documentation for supply chain security across BaSyx components. It adds high-level conceptual documentation, component-specific verification guides (especially for BaSyx Go), and an illustrative artifact diagram. It also updates navigation and cross-links to make these resources discoverable from related pages.

**Key documentation and navigation changes:**

*General supply chain security documentation:*
- Added a new conceptual overview page at `basyx_components/supply_chain_security.md` explaining supply chain security concepts, the evidence produced by BaSyx release pipelines, recommended practices for users, and key terminology. This includes a PlantUML diagram visualizing artifact relationships. [[1]](diffhunk://#diff-e0c900a348017712e88af486b1369280feadc1f2075570a875ba872d576a26e6R1-R92) [[2]](diffhunk://#diff-d5aa60d7e9c4881f47deb97a3786790d1238067d0c78d3625dcecf3e20e689e3R1-R59)

*Component-specific supply chain security guide:*
- Added a detailed guide at `basyx_components/go/supply_chain_security.md` covering how to verify signatures, provenance, SBOMs, and OCI attestations for BaSyx Go container images, with example commands and trust model explanations.

*Navigation and discoverability improvements:*
- Updated navigation files (`index.md` and `toctree` entries) for both general and Go-specific documentation to include the new supply chain security sections, ensuring users can easily find these resources. [[1]](diffhunk://#diff-716e797d11eac1ffea3b571080815aadebd8077692af561d9c10a2ef079c6c12R9) [[2]](diffhunk://#diff-716e797d11eac1ffea3b571080815aadebd8077692af561d9c10a2ef079c6c12R21) [[3]](diffhunk://#diff-02290a7dfabfb2b9d5a1f6b19bf07a3812e01c02c6b0958a399519fc6b85cff5R16) [[4]](diffhunk://#diff-02290a7dfabfb2b9d5a1f6b19bf07a3812e01c02c6b0958a399519fc6b85cff5R30)
- Added a cross-reference in the AAS Web UI security documentation to clarify the distinction between runtime access security and supply chain security, and to link to the new supply chain security documentation.