### PR TITLE
Document claim-based feature control

### DIFF
--- a/docs/source/content/developer_documentation/basyx_web_ui/configuration.md
+++ b/docs/source/content/developer_documentation/basyx_web_ui/configuration.md
@@ -158,11 +158,12 @@ The mapping has the following rules:
 * `sources` must contain at least one valid JSON Pointer.
 * A source may contain a string or an array of strings. Values from all sources are merged and deduplicated.
 * Missing sources contribute no values. A source that is present with another value type invalidates the feature set for that token.
+* Unsupported feature values invalidate the feature set instead of being ignored. This makes misspelled restrictive values visible in the browser console and prevents a partially applied set.
 * Malformed JSON, duplicate targets, unsupported modes, and invalid pointers invalidate the configuration.
 * An invalid or empty feature set restores the deployment defaults. Feature decisions do not depend on mapping or value order.
 * If the setting is absent, claim-based overrides are disabled.
 
-Token-derived values are reevaluated when authentication is restored, a user logs in or out, an access token is refreshed or removed, or the selected infrastructure changes. The configured deployment values remain unchanged and are restored when an override is unavailable.
+Token-derived values are reevaluated when authentication is restored, a user logs in or out, an access token is refreshed or removed, or the selected infrastructure changes. Expired tokens and infrastructures marked unauthenticated no longer provide overrides. The configured deployment values remain unchanged and are restored when an override is unavailable.
 
 | Feature value | Result |
 | --- | --- |
@@ -184,12 +185,54 @@ Keep backend authorization separate. For example, map a different user attribute
 
 ##### Microsoft Entra ID
 
-For Microsoft Entra ID, either expose a multivalued directory extension such as `extn.basyx_features` and use `/extn.basyx_features`, or use a custom claims provider that emits `basyx_features` and use `/basyx_features`. Configure the access-token claim on the resource application whose audience the UI requests.
+For Microsoft Entra ID, create a multivalued string directory extension through Microsoft Graph. Use the object ID of the application which owns the extension definition:
 
-BaSyx Go can independently consume the same raw claim with the equivalent trust-list entry:
+```http
+POST https://graph.microsoft.com/v1.0/applications/{extension-owner-object-id}/extensionProperties
+Content-Type: application/json
+
+{
+  "name": "basyx_features",
+  "dataType": "String",
+  "isMultiValued": true,
+  "targetObjects": ["User"]
+}
+```
+
+The response contains the full property name `extension_<appid-without-dashes>_basyx_features`. Populate that property on each user through Microsoft Graph or provisioning. Add the full property name to the BaSyx resource application's access-token optional claims:
 
 ```json
 {
+  "optionalClaims": {
+    "accessToken": [
+      {
+        "name": "extension_<appid-without-dashes>_basyx_features",
+        "source": "user",
+        "essential": false
+      }
+    ]
+  }
+}
+```
+
+Entra emits the directory extension in the JWT as `extn.basyx_features`. Set the UI environment variable to the complete mapping array:
+
+```json
+[
+  {
+    "target": "features",
+    "mode": "list",
+    "sources": ["/extn.basyx_features"]
+  }
+]
+```
+
+BaSyx Go can independently consume the same raw claim with this provider entry in its trust list:
+
+```json
+{
+  "issuer": "https://login.microsoftonline.com/{tenant-id}/v2.0",
+  "audience": "{basyx-resource-application-id}",
   "claimMappings": [
     {
       "target": "features",
@@ -200,7 +243,9 @@ BaSyx Go can independently consume the same raw claim with the equivalent trust-
 }
 ```
 
-BaSyx Go validates the token and creates the canonical `basyx.features` claim internally. The identity provider must not emit `basyx.features` directly because the `basyx.*` namespace is reserved and protected by BaSyx Go. Backend policies should use separately mapped permission attributes rather than treating UI feature values as authorization.
+Alternatively, use a custom claims provider which emits a string array named `basyx_features` and change both source pointers to `/basyx_features`.
+
+Access-token optional claims belong to the resource application whose audience the UI requests, not only to the SPA registration. BaSyx Go validates the token and creates the canonical `basyx.features` claim internally. The identity provider must not emit `basyx.features` directly because the `basyx.*` namespace is reserved and protected by BaSyx Go. Backend policies should use separately mapped permission attributes rather than treating UI feature values as authorization.
 
 A runnable Keycloak and BaSyx Go setup is available in the [ClaimBasedFeatureControl example](https://github.com/eclipse-basyx/basyx-aas-web-ui/tree/main/examples/ClaimBasedFeatureControl).
 

--- a/docs/source/content/developer_documentation/basyx_web_ui/configuration.md
+++ b/docs/source/content/developer_documentation/basyx_web_ui/configuration.md
@@ -133,27 +133,76 @@ Never commit OAuth client secrets or credentials into version control. Frontend 
 * `VITE_ALLOW_UPLOADING`
 * `VITE_ALLOW_LOGOUT`
 * `VITE_START_PAGE_ROUTE_NAME`
-* `VITE_KEYCLOAK_FEATURE_CONTROL`
-* `VITE_KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX`
+* `VITE_FEATURE_CONTROL_CLAIM_MAPPINGS`
 
-#### Feature Control based on OAuth2 roles
-To activate controlling features with the help of OAuth2 roles set `VITE_KEYCLOAK_FEATURE_CONTROL=true`
-Now `VITE_KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX` specifies the prefix of OAuth2 role names which controls de/activation of features.
-De/activation of features based on OAuth2 roles overwrites pre-~~configured~~ features!
+#### Claim-based feature control
 
-- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>endpoint-config-available` sets feature `VITE_ENDPOINT_CONFIG_AVAILABLE=true`
-- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>endpoint-config-unavailable` sets feature `VITE_ENDPOINT_CONFIG_AVAILABLE=false`
-- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>single-aas` sets feature `VITE_SINGLE_AAS=true`
-- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>multiple-aas` sets feature `VITE_SINGLE_AAS=false`
-- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>sm-viewer-editor` sets feature `VITE_SM_VIEWER_EDITOR=true`
-- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>single-sm` sets feature `VITE_SINGLE_SM=true`
-- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>multiple-sm` sets feature `VITE_SINGLE_SM=false`
-- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>allow-editing` sets feature `VITE_ALLOW_EDITING=true`
-- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>forbid-editing` sets feature `VITE_ALLOW_EDITING=false`
-- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>allow-uploading` sets feature `VITE_ALLOW_UPLOADING=true`
-- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>forbid-uploading` sets feature `VITE_ALLOW_UPLOADING=false`
-- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>allow-logout` sets feature `VITE_ALLOW_LOGOUT=true`
-- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>forbid-logout` sets feature `VITE_ALLOW_LOGOUT=false`
+Feature control can map claims from an OIDC access token to temporary UI feature overrides. It is identity-provider agnostic: claim locations are configured explicitly as [RFC 6901 JSON Pointers](https://www.rfc-editor.org/rfc/rfc6901), so the UI does not assume Keycloak roles or any other provider-specific token shape.
+
+Use `FEATURE_CONTROL_CLAIM_MAPPINGS` in production or `VITE_FEATURE_CONTROL_CLAIM_MAPPINGS` in development. The value follows the BaSyx Go claim-mapping shape:
+
+```json
+[
+  {
+    "target": "features",
+    "mode": "list",
+    "sources": ["/basyx_features"]
+  }
+]
+```
+
+The mapping has the following rules:
+
+* `target` must be `features` and may occur only once.
+* `mode` must be `list`.
+* `sources` must contain at least one valid JSON Pointer.
+* A source may contain a string or an array of strings. Values from all sources are merged and deduplicated.
+* Missing sources contribute no values. A source that is present with another value type invalidates the feature set for that token.
+* Malformed JSON, duplicate targets, unsupported modes, and invalid pointers invalidate the configuration.
+* An invalid or empty feature set restores the deployment defaults. Feature decisions do not depend on mapping or value order.
+* If the setting is absent, claim-based overrides are disabled.
+
+Token-derived values are reevaluated when authentication is restored, a user logs in or out, an access token is refreshed or removed, or the selected infrastructure changes. The configured deployment values remain unchanged and are restored when an override is unavailable.
+
+| Feature value | Result |
+| --- | --- |
+| `endpoint-config-available` / `endpoint-config-unavailable` | Show or hide endpoint configuration |
+| `single-aas` / `multiple-aas` | Use the single- or multiple-AAS presentation |
+| `sm-viewer-editor` | Enable separate Submodel viewer and editor routes |
+| `single-sm` / `multiple-sm` | Use the single- or multiple-Submodel presentation |
+| `allow-editing` / `forbid-editing` | Show or hide editing controls |
+| `allow-uploading` / `forbid-uploading` | Show or hide upload controls |
+| `allow-logout` / `forbid-logout` | Show or hide logout controls |
+
+If a token contains both values from a pair, the restrictive value wins: `endpoint-config-unavailable`, `single-aas`, `single-sm`, `forbid-editing`, `forbid-uploading`, or `forbid-logout`.
+
+##### Keycloak
+
+Create a multivalued `basyx_features` user attribute and add an OIDC **User Attribute** protocol mapper to the UI client. Configure the mapper to include the attribute as a multivalued string claim named `basyx_features` in access tokens. The mapping above then reads it from `/basyx_features`.
+
+Keep backend authorization separate. For example, map a different user attribute or client role to the permission claims consumed by BaSyx Go. Feature values only control UI presentation and never grant API permissions.
+
+##### Microsoft Entra ID
+
+For Microsoft Entra ID, either expose a multivalued directory extension such as `extn.basyx_features` and use `/extn.basyx_features`, or use a custom claims provider that emits `basyx_features` and use `/basyx_features`. Configure the access-token claim on the resource application whose audience the UI requests.
+
+BaSyx Go can independently consume the same raw claim with the equivalent trust-list entry:
+
+```json
+{
+  "claimMappings": [
+    {
+      "target": "features",
+      "mode": "list",
+      "sources": ["/extn.basyx_features"]
+    }
+  ]
+}
+```
+
+BaSyx Go validates the token and creates the canonical `basyx.features` claim internally. The identity provider must not emit `basyx.features` directly because the `basyx.*` namespace is reserved and protected by BaSyx Go. Backend policies should use separately mapped permission attributes rather than treating UI feature values as authorization.
+
+A runnable Keycloak and BaSyx Go setup is available in the [ClaimBasedFeatureControl example](https://github.com/eclipse-basyx/basyx-aas-web-ui/tree/main/examples/ClaimBasedFeatureControl).
 
 ### Miscellaneous
 

--- a/docs/source/content/developer_documentation/basyx_web_ui/configuration.md
+++ b/docs/source/content/developer_documentation/basyx_web_ui/configuration.md
@@ -105,8 +105,6 @@ These variables remain available to avoid breaking existing deployments but shou
 * `VITE_KEYCLOAK_URL` (**deprecated**; use `basyx-infra.yml` instead)
 * `VITE_KEYCLOAK_REALM` (**deprecated**; use `basyx-infra.yml` instead)
 * `VITE_KEYCLOAK_CLIENT_ID` (**deprecated**; use `basyx-infra.yml` instead)
-* `VITE_KEYCLOAK_FEATURE_CONTROL`
-* `VITE_KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX`
 * `VITE_OIDC_ACTIVE` (**deprecated**; automatically set in production if OIDC variables are present)
 * `VITE_OIDC_URL` (**deprecated**; use `basyx-infra.yml` instead)
 * `VITE_OIDC_SCOPE` (**deprecated**; use `basyx-infra.yml` instead)
@@ -135,6 +133,27 @@ Never commit OAuth client secrets or credentials into version control. Frontend 
 * `VITE_ALLOW_UPLOADING`
 * `VITE_ALLOW_LOGOUT`
 * `VITE_START_PAGE_ROUTE_NAME`
+* `VITE_KEYCLOAK_FEATURE_CONTROL`
+* `VITE_KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX`
+
+#### Feature Control based on OAuth2 roles
+To activate controlling features with the help of OAuth2 roles set `VITE_KEYCLOAK_FEATURE_CONTROL=true`
+Now `VITE_KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX` specifies the prefix of OAuth2 role names which controls de/activation of features.
+De/activation of features based on OAuth2 roles overwrites pre-~~configured~~ features!
+
+- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>endpoint-config-available` sets feature `VITE_ENDPOINT_CONFIG_AVAILABLE=true`
+- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>endpoint-config-unavailable` sets feature `VITE_ENDPOINT_CONFIG_AVAILABLE=false`
+- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>single-aas` sets feature `VITE_SINGLE_AAS=true`
+- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>multiple-aas` sets feature `VITE_SINGLE_AAS=false`
+- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>sm-viewer-editor` sets feature `VITE_SM_VIEWER_EDITOR=true`
+- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>single-sm` sets feature `VITE_SINGLE_SM=true`
+- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>multiple-sm` sets feature `VITE_SINGLE_SM=false`
+- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>allow-editing` sets feature `VITE_ALLOW_EDITING=true`
+- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>forbid-editing` sets feature `VITE_ALLOW_EDITING=false`
+- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>allow-uploading` sets feature `VITE_ALLOW_UPLOADING=true`
+- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>forbid-uploading` sets feature `VITE_ALLOW_UPLOADING=false`
+- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>allow-logout` sets feature `VITE_ALLOW_LOGOUT=true`
+- Role `<KEYCLOAK_FEATURE_CONTROL_ROLE_PREFIX>forbid-logout` sets feature `VITE_ALLOW_LOGOUT=false`
 
 ### Miscellaneous
 


### PR DESCRIPTION
## What changed

This replaces the original Keycloak-role documentation with the provider-neutral OIDC claim-mapping model implemented in [eclipse-basyx/basyx-aas-web-ui#1413](https://github.com/eclipse-basyx/basyx-aas-web-ui/pull/1413).

The page now documents:

- `FEATURE_CONTROL_CLAIM_MAPPINGS` and its development equivalent.
- Mapping validation, JSON Pointer sources, merging, strict feature-value handling, and restrictive conflicts.
- Every supported feature value and restoration behavior for expired or unauthenticated tokens.
- Keycloak multivalued user attributes.
- A complete Microsoft Entra ID directory-extension flow, including Microsoft Graph creation, optional access-token claims, the emitted `extn.*` claim, and the matching UI and BaSyx Go mappings.
- The protected BaSyx Go `basyx.*` namespace and the security boundary between UI presentation and backend authorization.
- The runnable Keycloak 26.7 and BaSyx Go example included in the UI PR.

The claim-based section now follows the page's existing CRLF line-ending style, avoiding the mixed line endings introduced by the earlier revision.

## Verification

The complete Sphinx site parsed and rendered the changed page successfully. A repository-wide warnings-as-errors build remains blocked by the existing documentation baseline (402 warnings, including the current MyST configuration and unrelated files); the changed page introduced no new diagnostic observed during the build.
