### PR TITLE
Document PostgreSQL pool defaults and sizing

### DIFF
--- a/docs/source/content/user_documentation/basyx_components/go/common/configuration.md
+++ b/docs/source/content/user_documentation/basyx_components/go/common/configuration.md
@@ -60,16 +60,30 @@ All HTTP timeout values must be greater than `0`. When a service receives an int
 | `sslkey` | `""` | Path to the private key belonging to `sslcert`. |
 | `sslrootcert` | `""` | Path to the root CA certificate used to verify the PostgreSQL server certificate. |
 | `connectTimeoutSeconds` | `0` | Connection timeout in seconds. Must not be negative; `0` leaves the timeout unspecified. |
-| `applicationName` | `""` | PostgreSQL `application_name` reported for the connection. |
+| `applicationName` | `""` | PostgreSQL `application_name` reported for the connection. When empty, the service name is used. |
 | `fallbackApplicationName` | `""` | Fallback application name used when no primary application name is supplied. |
 | `searchPath` | `""` | PostgreSQL schema search path for new sessions. |
 | `options` | `""` | Additional PostgreSQL server startup options. |
 | `timezone` | `""` | PostgreSQL session time zone. |
-| `maxOpenConnections` | `50` | Maximum number of open DB connections. |
-| `maxIdleConnections` | `50` | Maximum number of idle DB connections. |
-| `connMaxLifetimeMinutes` | `5` | Maximum DB connection lifetime in minutes. |
+| `maxOpenConnections` | `50` | Maximum number of open DB connections per service process or pod. `0` uses the default. |
+| `maxIdleConnections` | `25` | Maximum number of idle DB connections per service process or pod. `0` uses the default, capped at a smaller explicit open limit. |
+| `connMaxLifetimeMinutes` | `5` | Maximum DB connection lifetime in minutes. `0` uses the default. |
+| `connMaxIdleTimeMinutes` | `0` | Maximum time an idle connection is retained, in minutes. `0` disables idle-time recycling. |
 
 When `postgres.dsn` is non-empty, do not explicitly configure `host`, `port`, `user`, `password`, `dbname`, TLS, timeout, application-name, search-path, options, or time-zone fields in YAML or environment variables. The service rejects this ambiguous combination. Connection-pool settings can still be used with a DSN.
+
+If no primary `application_name` is supplied through `applicationName` or the DSN, the component sets it to its service name. An explicitly configured value is preserved. This identifies each BaSyx service in PostgreSQL views such as `pg_stat_activity`.
+
+The pool settings apply independently to every process or Kubernetes pod. Plan the PostgreSQL connection budget across all database-backed services and replicas:
+
+```text
+required application connections =
+  sum(maxOpenConnections per service × replica count)
+```
+
+Keep that total below PostgreSQL's usable connection budget and reserve connections for administration, monitoring, migrations, and rolling updates. The maximum is a limit rather than a guarantee that every pool always opens that many connections, but PostgreSQL must be able to handle the configured worst case. Idle connections are still open PostgreSQL sessions.
+
+All four pool values must be non-negative. An explicitly configured `maxIdleConnections` greater than the effective `maxOpenConnections` is rejected during startup. If `maxIdleConnections` is `0` and an explicit open limit is smaller than the default idle limit of `25`, the effective idle limit is capped at that smaller open limit.
 
 The DSN and database credentials are sensitive and should normally be supplied through a secret rather than committed to YAML.
 
@@ -247,8 +261,9 @@ postgres:
   options: ""
   timezone: ""
   maxOpenConnections: 50
-  maxIdleConnections: 50
+  maxIdleConnections: 25
   connMaxLifetimeMinutes: 5
+  connMaxIdleTimeMinutes: 0
 
 cors:
   allowedOrigins: []
@@ -353,6 +368,10 @@ POSTGRES_PASSWORD=admin123
 POSTGRES_DBNAME=basyxTestDB
 POSTGRES_SSLMODE=disable
 POSTGRES_CONNECTTIMEOUTSECONDS=10
+POSTGRES_MAXOPENCONNECTIONS=50
+POSTGRES_MAXIDLECONNECTIONS=25
+POSTGRES_CONNMAXLIFETIMEMINUTES=5
+POSTGRES_CONNMAXIDLETIMEMINUTES=0
 ABAC_ENABLED=false
 ABAC_POLICYFILEIMPORT=if_missing
 ABAC_POLICY_SCOPE=aasregistryservice
@@ -425,7 +444,9 @@ To use a complete PostgreSQL DSN, set only `POSTGRES_DSN` for the connection det
 ```bash
 POSTGRES_DSN=postgres://admin:secret@db:5432/basyx?sslmode=require
 POSTGRES_MAXOPENCONNECTIONS=50
-POSTGRES_MAXIDLECONNECTIONS=50
+POSTGRES_MAXIDLECONNECTIONS=25
+POSTGRES_CONNMAXLIFETIMEMINUTES=5
+POSTGRES_CONNMAXIDLETIMEMINUTES=0
 ```
 
 ## Security Files

--- a/docs/source/content/user_documentation/basyx_components/go/common/configuration.md
+++ b/docs/source/content/user_documentation/basyx_components/go/common/configuration.md
@@ -47,6 +47,10 @@ All HTTP timeout values must be greater than `0`. When a service receives an int
 
 ### `postgres`
 
+```{note}
+The pool defaults, `connMaxIdleTimeMinutes`, zero-value handling, validation rules, and automatic service-name fallback described below require BaSyx Go 1.0.5 or later.
+```
+
 | Key | Default | Purpose |
 | --- | --- | --- |
 | `dsn` | `""` | Complete PostgreSQL connection string. When non-empty, it replaces the individual connection fields listed below. |
@@ -74,14 +78,15 @@ When `postgres.dsn` is non-empty, do not explicitly configure `host`, `port`, `u
 
 If no primary `application_name` is supplied through `applicationName` or the DSN, the component sets it to its service name. An explicitly configured value is preserved. This identifies each BaSyx service in PostgreSQL views such as `pg_stat_activity`.
 
-The pool settings apply independently to every process or Kubernetes pod. Plan the PostgreSQL connection budget across all database-backed services and replicas:
+The pool settings apply independently to every process or Kubernetes pod. Calculate the connection budget separately for each PostgreSQL primary, including only clients that connect to that primary:
 
 ```text
 required application connections =
-  sum(maxOpenConnections per service × replica count)
+  sum(maxOpenConnections per BaSyx service × maximum concurrent replica count)
+  + non-BaSyx application pools
 ```
 
-Keep that total below PostgreSQL's usable connection budget and reserve connections for administration, monitoring, migrations, and rolling updates. The maximum is a limit rather than a guarantee that every pool always opens that many connections, but PostgreSQL must be able to handle the configured worst case. Idle connections are still open PostgreSQL sessions.
+Non-BaSyx clients include identity services such as Keycloak when they share the database. The maximum concurrent replica count must include temporary old and new pods during rolling updates. Keep the total below that primary's usable connection budget and reserve connections for administration, monitoring, migrations, and failover. The maximum is a limit rather than a guarantee that every pool always opens that many connections, but PostgreSQL must be able to handle the configured worst case. Idle connections are still open PostgreSQL sessions.
 
 All four pool values must be non-negative. An explicitly configured `maxIdleConnections` greater than the effective `maxOpenConnections` is rejected during startup. If `maxIdleConnections` is `0` and an explicit open limit is smaller than the default idle limit of `25`, the effective idle limit is capped at that smaller open limit.
 

--- a/docs/source/content/user_documentation/basyx_components/go/common/shared_features.md
+++ b/docs/source/content/user_documentation/basyx_components/go/common/shared_features.md
@@ -73,6 +73,10 @@ Multiple components reuse the same PostgreSQL configuration structure and connec
 - `postgres.connMaxLifetimeMinutes`
 - `postgres.connMaxIdleTimeMinutes`
 
+```{note}
+The pool behavior in this section requires BaSyx Go 1.0.5 or later.
+```
+
 Each service process or Kubernetes pod owns a separate pool. The common defaults are:
 
 | Setting | Default | Zero value |
@@ -82,7 +86,7 @@ Each service process or Kubernetes pod owns a separate pool. The common defaults
 | `connMaxLifetimeMinutes` | `5` | Uses the default. |
 | `connMaxIdleTimeMinutes` | `0` | Disables idle-time recycling. |
 
-An explicitly configured idle limit greater than the effective open limit is rejected at startup. When sizing replicas, add the open limits of every database-backed service pod and keep the total below PostgreSQL's usable connection budget. Reserve capacity for administration, monitoring, schema migration, and temporary overlap during rolling updates.
+An explicitly configured idle limit greater than the effective open limit is rejected at startup. Size each PostgreSQL primary independently: add the open limits of every BaSyx pod and other application pool connected to that primary, using the maximum concurrent replica count during rolling updates. Reserve capacity for administration, monitoring, schema migration, and failover.
 
 If `applicationName` and the DSN do not define a PostgreSQL `application_name`, the service name is used automatically. Explicit values are preserved. This makes per-service connections visible in `pg_stat_activity`.
 

--- a/docs/source/content/user_documentation/basyx_components/go/common/shared_features.md
+++ b/docs/source/content/user_documentation/basyx_components/go/common/shared_features.md
@@ -67,6 +67,23 @@ Multiple components reuse the same PostgreSQL configuration structure and connec
 - `postgres.dbname`
 - `postgres.user`
 - `postgres.password`
+- `postgres.applicationName`
 - `postgres.maxOpenConnections`
 - `postgres.maxIdleConnections`
 - `postgres.connMaxLifetimeMinutes`
+- `postgres.connMaxIdleTimeMinutes`
+
+Each service process or Kubernetes pod owns a separate pool. The common defaults are:
+
+| Setting | Default | Zero value |
+| --- | --- | --- |
+| `maxOpenConnections` | `50` | Uses the default. |
+| `maxIdleConnections` | `25` | Uses the default, capped at a smaller explicit open limit. |
+| `connMaxLifetimeMinutes` | `5` | Uses the default. |
+| `connMaxIdleTimeMinutes` | `0` | Disables idle-time recycling. |
+
+An explicitly configured idle limit greater than the effective open limit is rejected at startup. When sizing replicas, add the open limits of every database-backed service pod and keep the total below PostgreSQL's usable connection budget. Reserve capacity for administration, monitoring, schema migration, and temporary overlap during rolling updates.
+
+If `applicationName` and the DSN do not define a PostgreSQL `application_name`, the service name is used automatically. Explicit values are preserved. This makes per-service connections visible in `pg_stat_activity`.
+
+See [General Configuration](configuration) for the full PostgreSQL configuration and budgeting guidance.

--- a/docs/source/content/user_documentation/basyx_components/go/company_lookup/setup.md
+++ b/docs/source/content/user_documentation/basyx_components/go/company_lookup/setup.md
@@ -38,9 +38,10 @@ services:
       - POSTGRES_USER=admin
       - POSTGRES_PASSWORD=admin123
       - POSTGRES_DBNAME=basyxCompanyLookupDB
-      - POSTGRES_MAXOPENCONNECTIONS=500
-      - POSTGRES_MAXIDLECONNECTIONS=500
+      - POSTGRES_MAXOPENCONNECTIONS=50
+      - POSTGRES_MAXIDLECONNECTIONS=25
       - POSTGRES_CONNMAXLIFETIMEMINUTES=5
+      - POSTGRES_CONNMAXIDLETIMEMINUTES=0
     depends_on:
       postgres:
         condition: service_healthy
@@ -57,6 +58,10 @@ services:
       - POSTGRES_USER=admin
       - POSTGRES_PASSWORD=admin123
       - POSTGRES_DBNAME=basyxCompanyLookupDB
+      - POSTGRES_MAXOPENCONNECTIONS=50
+      - POSTGRES_MAXIDLECONNECTIONS=25
+      - POSTGRES_CONNMAXLIFETIMEMINUTES=5
+      - POSTGRES_CONNMAXIDLETIMEMINUTES=0
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully

--- a/docs/source/content/user_documentation/basyx_components/go/configuration_service/docker-compose.md
+++ b/docs/source/content/user_documentation/basyx_components/go/configuration_service/docker-compose.md
@@ -37,6 +37,7 @@ services:
       POSTGRES_MAXOPENCONNECTIONS: 50
       POSTGRES_MAXIDLECONNECTIONS: 25
       POSTGRES_CONNMAXLIFETIMEMINUTES: 5
+      POSTGRES_CONNMAXIDLETIMEMINUTES: 0
     depends_on:
       db:
         condition: service_healthy
@@ -49,6 +50,10 @@ services:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin123
       POSTGRES_DBNAME: basyxTestDB
+      POSTGRES_MAXOPENCONNECTIONS: 50
+      POSTGRES_MAXIDLECONNECTIONS: 25
+      POSTGRES_CONNMAXLIFETIMEMINUTES: 5
+      POSTGRES_CONNMAXIDLETIMEMINUTES: 0
     depends_on:
       basyx_configuration:
         condition: service_completed_successfully
@@ -67,6 +72,8 @@ Recommended ordering:
 4. BaSyx services start.
 
 Use `condition: service_completed_successfully` for services that depend on the database schema being initialized.
+
+Each container process has its own PostgreSQL pool. In this example, the Configuration Service exits before the Submodel Repository starts, so their configured limits do not normally overlap. Account for both during manual restarts or upgrades where they may run at the same time, and add the limits of all concurrently running service replicas when sizing PostgreSQL.
 
 ```{warning}
 Mutable image tags such as `latest` and `SNAPSHOT` can change between restarts. If images are pulled fresh on restart, run `basyx_configuration` before DB-backed runtime services because schema requirements may have changed.

--- a/docs/source/content/user_documentation/basyx_components/go/configuration_service/kubernetes-job.md
+++ b/docs/source/content/user_documentation/basyx_components/go/configuration_service/kubernetes-job.md
@@ -42,6 +42,8 @@ spec:
               value: "25"
             - name: POSTGRES_CONNMAXLIFETIMEMINUTES
               value: "5"
+            - name: POSTGRES_CONNMAXIDLETIMEMINUTES
+              value: "0"
 ```
 
 ## Secret Example
@@ -75,4 +77,5 @@ Common approaches include:
 - Avoid mutable image tags such as `latest` and `SNAPSHOT` for reproducible deployments. Pin exact image versions or image digests where possible.
 - If mutable-tag images are pulled fresh on restart, run the Configuration Service Job before DB-backed runtime workloads.
 - Ensure PostgreSQL is reachable and ready before the Job runs.
+- Include the Job's pool in the PostgreSQL connection budget while it overlaps with existing workloads during installation or upgrades. Each runtime pod has a separate pool.
 - Check Job logs when initialization fails; errors include BaSyx error codes for troubleshooting.

--- a/docs/source/content/user_documentation/basyx_components/go/configuration_service/usage.md
+++ b/docs/source/content/user_documentation/basyx_components/go/configuration_service/usage.md
@@ -37,6 +37,7 @@ postgres:
   maxOpenConnections: 50
   maxIdleConnections: 25
   connMaxLifetimeMinutes: 5
+  connMaxIdleTimeMinutes: 0
 ```
 
 Environment variables can also be used in the same style as other BaSyx services, for example:
@@ -50,7 +51,10 @@ POSTGRES_DBNAME=basyxTestDB
 POSTGRES_MAXOPENCONNECTIONS=50
 POSTGRES_MAXIDLECONNECTIONS=25
 POSTGRES_CONNMAXLIFETIMEMINUTES=5
+POSTGRES_CONNMAXIDLETIMEMINUTES=0
 ```
+
+The Configuration Service owns its own pool while the job is running. Include it in the PostgreSQL connection budget during startup and upgrades. Runtime services create separate pools in their own processes or pods. See [General Configuration](../common/configuration) for zero-value semantics and pool sizing.
 
 ## Patch Execution
 


### PR DESCRIPTION
## What changed

- corrected the shared PostgreSQL pool defaults and added `connMaxIdleTimeMinutes`
- documented zero-value handling and invalid idle/open combinations
- added per-primary connection budgeting guidance for BaSyx pods, other clients, and rolling updates
- documented the automatic PostgreSQL `application_name`
- marked the new pool behavior as requiring BaSyx Go 1.0.5 or later
- aligned the Configuration Service and Company Lookup examples

## Why

The pool setup was centralized in [basyx-go-components #537](https://github.com/eclipse-basyx/basyx-go-components/pull/537), but parts of the wiki still described the old defaults and showed 500 open and idle connections.

This PR should be merged with or after the BaSyx Go 1.0.5 release so the documented behavior is available in a published version.

## Checks

- searched all BaSyx Go wiki sources for the four pool settings
- `git diff --check`
- full Sphinx HTML build

The HTML build succeeds with the existing repository warnings.
