### PR TITLE
Document PostgreSQL pool metrics and Kubernetes connection pooling

### DIFF
--- a/docs/source/content/user_documentation/basyx_components/go/common/configuration.md
+++ b/docs/source/content/user_documentation/basyx_components/go/common/configuration.md
@@ -148,7 +148,10 @@ The complete value set and its defaults are:
 When enabled, eligible services connect to
 `<database.clusterName>-rw-pooler`. The chart replaces only `POSTGRES_HOST`;
 the port, database name, user, password, and other settings still come from the
-managed cluster's application Secret.
+managed cluster's application Secret. For long cluster names, the chart
+truncates the cluster-name portion of the Pooler service name to keep the
+generated name within 63 characters and distinct from the CloudNativePG
+Cluster name.
 
 The routing rules are intentionally narrower than a global host replacement:
 

--- a/docs/source/content/user_documentation/basyx_components/go/common/configuration.md
+++ b/docs/source/content/user_documentation/basyx_components/go/common/configuration.md
@@ -25,7 +25,9 @@ These sections are part of the shared configuration model. Components ignore set
 
 All diagnostic logs are written to standard error. See
 [Observability](observability) for request logging, correlation IDs,
-OpenTelemetry tracing, and log collection.
+OpenTelemetry tracing and metrics, and log collection. OpenTelemetry settings
+are standard `OTEL_*` environment variables rather than keys in this YAML
+configuration model.
 
 ### `server`
 

--- a/docs/source/content/user_documentation/basyx_components/go/common/configuration.md
+++ b/docs/source/content/user_documentation/basyx_components/go/common/configuration.md
@@ -92,6 +92,120 @@ Non-BaSyx clients include identity services such as Keycloak when they share the
 
 All four pool values must be non-negative. An explicitly configured `maxIdleConnections` greater than the effective `maxOpenConnections` is rejected during startup. If `maxIdleConnections` is `0` and an explicit open limit is smaller than the default idle limit of `25`, the effective idle limit is capped at that smaller open limit.
 
+#### Optional CloudNativePG connection pooler
+
+```{note}
+The `database.pooler` values require BaSyx Helm chart `3.7.0` or newer. They
+configure a CloudNativePG `Pooler` resource and are not BaSyx application YAML
+settings.
+```
+
+For a database managed by the chart, an optional read-write PgBouncer layer can
+decouple the number of client connections opened by horizontally scaled BaSyx
+pods from the number of PostgreSQL server processes:
+
+```yaml
+database:
+  pooler:
+    enabled: true
+    instances: 2
+    poolMode: transaction
+    maxClientConn: 1000
+    defaultPoolSize: 25
+    preparedStatements:
+      enabled: true
+      maxPreparedStatements: 100
+    parameters:
+      reserve_pool_size: "5"
+    resources:
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    nodeSelector: {}
+    affinity: {}
+    tolerations: []
+    topologySpreadConstraints: []
+```
+
+The complete value set and its defaults are:
+
+| Key | Default | Purpose |
+| --- | --- | --- |
+| `database.pooler.enabled` | `false` | Renders the managed read-write Pooler and routes eligible runtime services through it. |
+| `database.pooler.instances` | `2` | Number of PgBouncer pods. |
+| `database.pooler.poolMode` | `transaction` | PgBouncer pooling mode: `transaction` or `session`. |
+| `database.pooler.maxClientConn` | `1000` | Maximum client connections accepted by each PgBouncer pod. |
+| `database.pooler.defaultPoolSize` | `25` | Default PostgreSQL server connections per PgBouncer pod and user/database pair. |
+| `database.pooler.preparedStatements.enabled` | `true` | Enables PgBouncer protocol-level prepared-statement tracking. |
+| `database.pooler.preparedStatements.maxPreparedStatements` | `100` | Maximum tracked prepared statements when tracking is enabled. |
+| `database.pooler.parameters` | `{}` | Additional PgBouncer parameters as lowercase keys with string values. |
+| `database.pooler.resources` | `{}` | Requests and limits for the PgBouncer container. |
+| `database.pooler.nodeSelector` | `{}` | Node labels used to place Pooler pods. |
+| `database.pooler.affinity` | `{}` | Node, pod, and pod anti-affinity for Pooler pods. |
+| `database.pooler.tolerations` | `[]` | Tolerations for Pooler pods. |
+| `database.pooler.topologySpreadConstraints` | `[]` | Topology-spread constraints for Pooler pods. |
+
+When enabled, eligible services connect to
+`<database.clusterName>-rw-pooler`. The chart replaces only `POSTGRES_HOST`;
+the port, database name, user, password, and other settings still come from the
+managed cluster's application Secret.
+
+The routing rules are intentionally narrower than a global host replacement:
+
+- BaSyx runtime services that use the global managed database connect through
+  the Pooler.
+- The Configuration Service wait and migration containers connect directly to
+  the CloudNativePG read-write service. Migrations use session-level advisory
+  locks and must not run through transaction pooling.
+- Keycloak keeps its direct JDBC connection to the read-write service.
+- A service with its own `database` override, whether inline or through
+  `existingSecret`, keeps the host from that override and is not redirected.
+- `database.type=external` never renders or uses this Pooler. If an external
+  database needs PgBouncer, operate it separately and put its endpoint in the
+  external database Secret.
+
+Transaction pooling requires prepared-statement tracking for clients that use
+protocol-level prepared statements. The chart therefore renders
+`max_prepared_statements=100` by default. Setting
+`preparedStatements.enabled=false` explicitly renders
+`max_prepared_statements=0` and should only be done after verifying that the
+complete workload does not need prepared statements. The first-class client
+limit, server pool size, and prepared-statement values take precedence if the
+same keys are also present under `parameters`. Additional parameters must be
+supported by the PgBouncer version bundled with the installed CloudNativePG
+operator.
+
+Size the client side and server side separately. The aggregate application
+pool limit should fit within the Pooler client capacity with headroom for
+uneven load, rolling updates, and a failed Pooler pod:
+
+```text
+sum(maxOpenConnections per BaSyx pod × maximum concurrent replica count)
+< surviving Pooler instances × maxClientConn
+```
+
+For one user/database pair and no additional server-pool parameters, a starting
+estimate for PostgreSQL connections is:
+
+```text
+Pooler instances × (defaultPoolSize + reserve_pool_size)
++ direct Keycloak connections
++ migrations, monitoring, administration, and failover reserve
+< PostgreSQL max_connections
+```
+
+Adjust the estimate for every active user/database pair and for additional
+PgBouncer limits. A Pooler queues excess client work; it does not add write
+capacity to the PostgreSQL primary. If latency remains high, compare the BaSyx
+[PostgreSQL pool metrics](observability)
+with `cnpg_pgbouncer_*` metrics and PostgreSQL query, lock, storage, and CPU
+data before increasing the server pool.
+
+Before enabling transaction pooling in production, render the chart against
+the installed CloudNativePG CRDs and test the deployed BaSyx version through
+the Pooler. Include bulk endpoints, large-object operations, connection
+saturation, rolling updates, and a PostgreSQL switchover.
+
 The DSN and database credentials are sensitive and should normally be supplied through a secret rather than committed to YAML.
 
 ### `cors`

--- a/docs/source/content/user_documentation/basyx_components/go/common/observability.md
+++ b/docs/source/content/user_documentation/basyx_components/go/common/observability.md
@@ -1,15 +1,16 @@
 # Observability
 
-BaSyx Go provides structured application logging, request correlation, and
-optional OpenTelemetry tracing through shared runtime infrastructure. The
-features described on this page are available in `SNAPSHOT` images and in
-BaSyx Go `1.0.4` or newer.
+BaSyx Go provides structured application logging, request correlation, optional
+OpenTelemetry tracing, and PostgreSQL connection-pool metrics through shared
+runtime infrastructure. Logging and tracing are available in BaSyx Go `1.0.4`
+or newer. The pool metrics require BaSyx Go `1.0.6` or newer.
 
 The application remains independent of a particular observability backend:
 
 ```text
 BaSyx JSON stderr --> platform log collector --> Loki or another log store
 BaSyx OTLP traces --> OpenTelemetry Collector --> Tempo, Jaeger, or another trace store
+BaSyx OTLP metrics --> OpenTelemetry Collector --> Prometheus or another metric store
 ```
 
 BaSyx does not contain direct clients for Grafana, Loki, Tempo, or Jaeger.
@@ -27,7 +28,7 @@ logging:
 
 The equivalent environment variables are:
 
-```env
+```text
 LOGGING_FORMAT=text
 LOGGING_LEVEL=info
 ```
@@ -83,16 +84,21 @@ size, and request duration. Query strings, arbitrary headers, request and
 response bodies, authorization values, tokens, user agents, and client IP
 addresses are not recorded.
 
-## OpenTelemetry Tracing
+## OpenTelemetry Tracing and Metrics
 
-Tracing is optional and environment-only. It is disabled when
-`OTEL_TRACES_EXPORTER` is unset, empty, or `none`, or when
-`OTEL_SDK_DISABLED=true`.
+Tracing and metrics are optional and configured independently through standard
+OpenTelemetry environment variables. They are not BaSyx YAML configuration
+keys.
+
+- Tracing is disabled when `OTEL_TRACES_EXPORTER` is unset, empty, or `none`.
+- Metrics are disabled when `OTEL_METRICS_EXPORTER` is unset, empty, or `none`.
+- `OTEL_SDK_DISABLED=true` disables both signals.
 
 The typical Collector configuration is:
 
-```env
+```text
 OTEL_TRACES_EXPORTER=otlp
+OTEL_METRICS_EXPORTER=otlp
 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.observability.svc:4318
 OTEL_RESOURCE_ATTRIBUTES=deployment.environment.name=production
@@ -100,20 +106,45 @@ OTEL_TRACES_SAMPLER=parentbased_traceidratio
 OTEL_TRACES_SAMPLER_ARG=0.1
 ```
 
-The `console` exporter is available for local diagnostics. The default sampler
-is parent-based and always-on, so high-volume deployments should configure an
-appropriate sampling ratio.
+Either signal can be enabled without the other. The `console` exporter is
+available for local diagnostics. Supported explicit exporter values are
+`otlp`, `console`, and `none`.
+
+The default trace sampler is parent-based and always-on, so high-volume
+deployments should configure an appropriate sampling ratio.
 
 BaSyx supports the standard OpenTelemetry Go environment variables for:
 
-- OTLP endpoints, protocols, headers, compression, and timeouts
+- the generic OTLP endpoint, protocol, headers, compression, and timeout:
+  `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`,
+  `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_COMPRESSION`, and
+  `OTEL_EXPORTER_OTLP_TIMEOUT`
+- trace-specific overrides:
+  `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`,
+  `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`,
+  `OTEL_EXPORTER_OTLP_TRACES_HEADERS`,
+  `OTEL_EXPORTER_OTLP_TRACES_COMPRESSION`, and
+  `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT`
+- metric-specific overrides:
+  `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`,
+  `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL`,
+  `OTEL_EXPORTER_OTLP_METRICS_HEADERS`,
+  `OTEL_EXPORTER_OTLP_METRICS_COMPRESSION`, and
+  `OTEL_EXPORTER_OTLP_METRICS_TIMEOUT`
 - `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES`
 - trace sampling and batch span processing (`OTEL_TRACES_*` and `OTEL_BSP_*`)
+- the metric export interval and timeout through
+  `OTEL_METRIC_EXPORT_INTERVAL` and `OTEL_METRIC_EXPORT_TIMEOUT`
 - W3C Trace Context and Baggage propagation through `OTEL_PROPAGATORS`
 
-The default trace resource `service.name` is the lowercase BaSyx command name,
-for example `aasenvironmentservice`. An explicit `OTEL_SERVICE_NAME` overrides
-it.
+The signal-specific endpoint, protocol, headers, compression, and timeout
+override their generic counterparts for that signal. The export interval and
+timeout are positive integer values in milliseconds. If no endpoint is
+specified, the OpenTelemetry SDK's normal OTLP defaults apply.
+
+The default telemetry resource `service.name` is the lowercase BaSyx command
+name, for example `aasenvironmentservice`. An explicit `OTEL_SERVICE_NAME`
+overrides it.
 
 Each inbound HTTP request creates a server span. Valid W3C `traceparent` and
 `tracestate` values are preserved, while requests without trace context start a
@@ -124,6 +155,59 @@ discovery, are not instrumented.
 Export happens asynchronously in batches. An unavailable Collector does not
 prevent service startup or fail HTTP requests; telemetry can be dropped while
 the backend is unavailable. Shutdown uses a bounded flush period.
+
+### PostgreSQL Connection-Pool Metrics
+
+Each supported HTTP service registers its shared PostgreSQL writer pool once.
+Metric collection reads Go's in-process `database/sql.DBStats()` and does not
+run additional database queries.
+
+| Metric | Type | Meaning |
+| --- | --- | --- |
+| `db.client.connection.max` | Up/down counter | Configured maximum number of open connections |
+| `db.client.connection.count` with `db.client.connection.state=used` | Up/down counter | Connections currently in use |
+| `db.client.connection.count` with `db.client.connection.state=idle` | Up/down counter | Connections currently idle |
+| `basyx.db.client.connection.waits` | Cumulative counter | Requests that waited for a connection |
+| `basyx.db.client.connection.wait_time` | Cumulative counter in seconds | Total time spent waiting for connections |
+| `basyx.db.client.connection.closed` with `basyx.db.client.connection.close.reason=idle_limit` | Cumulative counter | Connections closed because of the idle-count limit |
+| `basyx.db.client.connection.closed` with `basyx.db.client.connection.close.reason=idle_time` | Cumulative counter | Connections closed after their maximum idle time |
+| `basyx.db.client.connection.closed` with `basyx.db.client.connection.close.reason=max_lifetime` | Cumulative counter | Connections closed after their maximum lifetime |
+
+Open connections are the sum of the `used` and `idle` points on
+`db.client.connection.count`. Every point has
+`db.system.name=postgresql` and
+`db.client.connection.pool.name=writer`. The `service.name` resource attribute
+identifies the service instance.
+
+Use rates rather than raw totals for the cumulative wait and closure counters.
+A rising wait rate while the number of used connections approaches
+`db.client.connection.max` indicates that the application pool is constraining
+concurrency. Low utilization with slow requests points elsewhere, for example
+to query execution, PostgreSQL capacity, or storage latency. Pool metrics show
+client-side pressure; they do not measure query duration or increase database
+capacity.
+
+The metric attributes are intentionally bounded. Database names, hosts, users,
+DSNs, SQL text, AAS identifiers, and request data are not recorded. Do not copy
+such values into `OTEL_RESOURCE_ATTRIBUTES`, because resource attributes are
+attached to every exported data point.
+
+Pool metrics are available for these HTTP services:
+
+- AAS Environment
+- AAS Repository
+- AAS Registry
+- AASX File Server
+- Basic Discovery
+- Company Lookup
+- Concept Description Repository
+- Digital Product Passport API
+- Digital Twin Registry
+- Submodel Repository
+- Submodel Registry
+
+The Configuration Service and History Evidence Verifier remain logging-only
+commands. They do not expose HTTP servers or long-running telemetry runtimes.
 
 ## Correlating Logs and Traces
 
@@ -149,13 +233,28 @@ The [BaSyx Go observability
 example](https://github.com/eclipse-basyx/basyx-go-components/tree/main/examples/BaSyxObservabilityExample)
 provides a local development stack with an AAS Environment, BaSyx Web UI,
 OpenTelemetry Collector, Tempo, Loki, Alloy, and Grafana. It verifies trace
-export, structured-log ingestion, trace-to-log correlation, and continued
-service operation during a Collector outage.
+and metric export, structured-log ingestion, trace-to-log correlation, and
+continued service operation during a Collector outage.
 
 For Kubernetes, the [BaSyx Helm
 chart](https://github.com/eclipse-basyx/charts) exposes common logging and
-tracing values. Its observability values example connects BaSyx workloads to an
-existing Collector. The chart intentionally does not install Grafana, Loki,
+telemetry values. Its observability values example connects BaSyx workloads to
+an existing Collector:
+
+```yaml
+telemetry:
+  tracesExporter: otlp
+  metricsExporter: otlp
+  endpoint: http://opentelemetry-collector.observability.svc.cluster.local:4318
+  protocol: http/protobuf
+  metricsExportInterval: "60000"
+  metricsExportTimeout: "30000"
+```
+
+The generic endpoint and protocol apply to both signals. Signal-specific OTLP
+overrides and credentials can be supplied through `environment.common` or
+`telemetry.existingSecret`. Store OTLP authorization headers in a Secret rather
+than a values file. The chart intentionally does not install Grafana, Loki,
 Tempo, or Alloy because authentication, storage, retention, resource sizing,
 and tenancy should be designed for the target cluster.
 
@@ -166,7 +265,8 @@ and least-privilege log collection.
 
 ## Current Scope
 
-BaSyx Go currently provides traces, structured logs, and log-to-trace
-correlation. It does not provide OpenTelemetry metrics, direct OTLP log export,
-database spans, AAS-domain spans, arbitrary outbound HTTP propagation, or
-runtime telemetry reconfiguration.
+BaSyx Go currently provides traces, PostgreSQL pool metrics, structured logs,
+and log-to-trace correlation. It does not provide direct OTLP log export,
+database query spans, SQL statement capture, query-duration metrics,
+AAS-domain spans, arbitrary outbound HTTP propagation, runtime telemetry
+reconfiguration, or a built-in metrics endpoint.

--- a/docs/source/content/user_documentation/basyx_components/go/common/observability.md
+++ b/docs/source/content/user_documentation/basyx_components/go/common/observability.md
@@ -177,7 +177,9 @@ Open connections are the sum of the `used` and `idle` points on
 `db.client.connection.count`. Every point has
 `db.system.name=postgresql` and
 `db.client.connection.pool.name=writer`. The `service.name` resource attribute
-identifies the service instance.
+identifies the BaSyx service, not an individual replica. For per-pod diagnosis
+in a horizontally scaled deployment, configure the Collector to attach bounded
+Kubernetes resource attributes such as `k8s.pod.name` or `k8s.pod.uid`.
 
 Use rates rather than raw totals for the cumulative wait and closure counters.
 A rising wait rate while the number of used connections approaches
@@ -251,12 +253,25 @@ telemetry:
   metricsExportTimeout: "30000"
 ```
 
+These metric values require BaSyx Helm chart `3.7.0` and BaSyx Go `1.0.6` or
+newer. `metricsExporter`, `metricsExportInterval`, and
+`metricsExportTimeout` render `OTEL_METRICS_EXPORTER`,
+`OTEL_METRIC_EXPORT_INTERVAL`, and `OTEL_METRIC_EXPORT_TIMEOUT` respectively.
+Their defaults are `none`, an empty interval, and an empty timeout. Empty
+timing values use the OpenTelemetry SDK defaults; configured values must be
+positive milliseconds.
+
 The generic endpoint and protocol apply to both signals. Signal-specific OTLP
-overrides and credentials can be supplied through `environment.common` or
-`telemetry.existingSecret`. Store OTLP authorization headers in a Secret rather
-than a values file. The chart intentionally does not install Grafana, Loki,
-Tempo, or Alloy because authentication, storage, retention, resource sizing,
-and tenancy should be designed for the target cluster.
+overrides and credentials can be supplied through `environment.common`, a
+service's `environment` map, or `telemetry.existingSecret`. Store OTLP
+authorization headers in a Secret rather than a values file. Changes to
+structured telemetry values update the backend pod template checksum. Changing
+only the contents of an existing Secret does not, so restart the backend pods
+after rotating those values.
+
+The chart intentionally does not install the Collector, Grafana, Loki, Tempo,
+or Alloy because authentication, storage, retention, resource sizing, and
+tenancy should be designed for the target cluster.
 
 The local Compose stack is a development example, not a production deployment
 reference. Production environments should use authenticated telemetry

--- a/docs/source/content/user_documentation/basyx_components/go/common/shared_features.md
+++ b/docs/source/content/user_documentation/basyx_components/go/common/shared_features.md
@@ -42,13 +42,14 @@ services also provide canonical request and correlation IDs and emit one
 access-log event per request. See [Observability](observability) for the logging
 contract and header behavior.
 
-## Optional OpenTelemetry Tracing
+## Optional OpenTelemetry Telemetry
 
 HTTP services can create OpenTelemetry server spans and correlate contextual
-logs with trace and span IDs. Tracing is disabled by default and configured
-through standard OpenTelemetry environment variables. See
-[Observability](observability) for activation, propagation, sampling, and
-backend integration.
+logs with trace and span IDs. They can also export shared PostgreSQL
+connection-pool metrics. Tracing and metrics are disabled independently by
+default and configured through standard OpenTelemetry environment variables.
+See [Observability](observability) for activation, propagation, sampling,
+metric interpretation, and backend integration.
 
 ## Shared Security Building Blocks
 


### PR DESCRIPTION
## What changed

- document optional PostgreSQL connection pool metrics in BaSyx Go 1.0.6
- explain how tracing and metrics can be enabled independently through standard OpenTelemetry environment variables
- list the exported metric names and attributes, including how to interpret cumulative wait and closure counters
- document the optional CloudNativePG read-write Pooler, its values and routing boundaries
- explain the separate BaSyx client, PgBouncer server pool, and PostgreSQL connection budgets
- cover transaction pooling, prepared statements, service-local database overrides, external databases, scheduling, generated-name handling, and production rollout gates
- clarify that OpenTelemetry and Helm settings are not BaSyx application YAML configuration keys

## Dependencies

This PR documents:

- [eclipse-basyx/basyx-go-components#538](https://github.com/eclipse-basyx/basyx-go-components/pull/538), released in BaSyx Go 1.0.6
- [eclipse-basyx/charts#90](https://github.com/eclipse-basyx/charts/pull/90)

It should remain a draft until BaSyx Helm chart 3.7.0 is available.

## Validation

- `git diff --check`
- Sphinx HTML build
- cross-check against the chart values, schema, templates, and tests in charts PR #90

The Sphinx build completes successfully. The existing repository-wide MyST, cross-reference, and external-source warnings remain, with no warnings from the changed pages.