### PR TITLE
Document PostgreSQL read replica configuration

### DIFF
--- a/docs/source/content/user_documentation/basyx_components/go/common/configuration.md
+++ b/docs/source/content/user_documentation/basyx_components/go/common/configuration.md
@@ -185,6 +185,11 @@ immediate revocation or read-after-write consistency must omit the reader for
 the affected service or use replication guarantees that meet their required
 consistency window.
 
+Compound responses are assembled in one read-only repeatable-read transaction.
+This keeps all SQL queries for that response on one reader connection and one
+database snapshot, so a resource is not combined from different replica
+positions. Separate requests can still observe different replay positions.
+
 Both configured pools must be reachable during service startup. A reader
 outage after startup is not silently routed to the writer. In production:
 

--- a/docs/source/content/user_documentation/basyx_components/go/common/configuration.md
+++ b/docs/source/content/user_documentation/basyx_components/go/common/configuration.md
@@ -80,6 +80,122 @@ When `postgres.dsn` is non-empty, do not explicitly configure `host`, `port`, `u
 
 If no primary `application_name` is supplied through `applicationName` or the DSN, the component sets it to its service name. An explicitly configured value is preserved. This identifies each BaSyx service in PostgreSQL views such as `pg_stat_activity`.
 
+#### Optional PostgreSQL reader
+
+```{note}
+The `postgres.reader` configuration requires BaSyx Go 1.0.7 or later.
+```
+
+PostgreSQL-backed BaSyx HTTP services can use a separate reader connection for
+eligible, eventually consistent reads. Configure it as a nested
+`postgres.reader` block:
+
+```yaml
+postgres:
+  host: postgres-primary
+  port: 5432
+  user: basyx
+  password: change-me
+  dbname: basyx
+  sslmode: verify-full
+  sslrootcert: /run/secrets/postgres/ca.crt
+  maxOpenConnections: 30
+  maxIdleConnections: 15
+  connMaxLifetimeMinutes: 5
+  connMaxIdleTimeMinutes: 1
+
+  reader:
+    host: postgres-reader
+    port: 5432
+    user: basyx_reader
+    password: change-me
+    dbname: basyx
+    sslmode: verify-full
+    sslrootcert: /run/secrets/postgres/ca.crt
+    maxOpenConnections: 60
+    maxIdleConnections: 30
+    connMaxLifetimeMinutes: 5
+    connMaxIdleTimeMinutes: 1
+```
+
+The reader supports the same connection and pool keys as the writer:
+
+| YAML key below `postgres.reader` | Environment variable | Default or requirement |
+| --- | --- | --- |
+| `dsn` | `POSTGRES_READER_DSN` | Optional complete reader connection string. |
+| `host` | `POSTGRES_READER_HOST` | Required when `dsn` is not set. |
+| `port` | `POSTGRES_READER_PORT` | `5432` |
+| `user` | `POSTGRES_READER_USER` | No writer-value inheritance. |
+| `password` | `POSTGRES_READER_PASSWORD` | No writer-value inheritance. |
+| `dbname` | `POSTGRES_READER_DBNAME` | Required when `dsn` is not set. |
+| `sslmode` | `POSTGRES_READER_SSLMODE` | Empty uses the PostgreSQL driver behavior. |
+| `sslcert` | `POSTGRES_READER_SSLCERT` | `""` |
+| `sslkey` | `POSTGRES_READER_SSLKEY` | `""` |
+| `sslrootcert` | `POSTGRES_READER_SSLROOTCERT` | `""` |
+| `connectTimeoutSeconds` | `POSTGRES_READER_CONNECTTIMEOUTSECONDS` | `0` leaves the timeout unspecified. |
+| `applicationName` | `POSTGRES_READER_APPLICATIONNAME` | Empty uses `<service-name>-reader`. |
+| `fallbackApplicationName` | `POSTGRES_READER_FALLBACKAPPLICATIONNAME` | `""` |
+| `searchPath` | `POSTGRES_READER_SEARCHPATH` | `""` |
+| `options` | `POSTGRES_READER_OPTIONS` | `""` |
+| `timezone` | `POSTGRES_READER_TIMEZONE` | `""` |
+| `maxOpenConnections` | `POSTGRES_READER_MAXOPENCONNECTIONS` | `50` when set to `0`. |
+| `maxIdleConnections` | `POSTGRES_READER_MAXIDLECONNECTIONS` | `25` when set to `0`, capped at a smaller open limit. |
+| `connMaxLifetimeMinutes` | `POSTGRES_READER_CONNMAXLIFETIMEMINUTES` | `5` when set to `0`. |
+| `connMaxIdleTimeMinutes` | `POSTGRES_READER_CONNMAXIDLETIMEMINUTES` | `0` disables idle-time recycling. |
+
+Use either `postgres.reader.dsn` or the individual reader connection fields,
+not both. Reader settings do not inherit connection fields or pool limits from
+the writer. Omitting the complete reader configuration reuses the writer pool
+and preserves the behavior of earlier releases. Pointing both configurations
+to the same PostgreSQL endpoint is also supported, but does not add database
+read capacity and both pools then consume the same server connection budget.
+A physical standby is a separate PostgreSQL instance that replicates the same
+database, not an independent database.
+
+Reader routing is supported by:
+
+- AAS Registry
+- Submodel Registry
+- Discovery Service
+- Digital Twin Registry
+- AAS Repository
+- Submodel Repository
+- Concept Description Repository
+- AAS Environment, including the repository, registry, and discovery APIs it
+  hosts
+- AASX File Server
+- Company Lookup Service
+- DPP API
+
+Eligible retrieval requests use the reader. This decision is based on the
+operation's consistency requirements, not on the number of SQL queries needed
+to complete a request. Mutations, mutation guards and prechecks, transactions,
+read-after-write paths, schema validation, asynchronous jobs, operation
+invocation, authorization policy storage, and upload or binary staging remain
+on the writer. The Configuration Service and History Evidence Verifier are
+writer-only.
+
+Configuring a reader opts the service into eventual consistency. PostgreSQL
+replication lag can make a successful write appear later through a
+reader-routed request. The same applies to deletions and
+authorization-relevant attribute changes: the current authorization middleware
+and filters are still applied, but a reader can briefly return the preceding
+resource state after access should have been revoked. Deployments that require
+immediate revocation or read-after-write consistency must omit the reader for
+the affected service or use replication guarantees that meet their required
+consistency window.
+
+Both configured pools must be reachable during service startup. A reader
+outage after startup is not silently routed to the writer. In production:
+
+- use distinct writer and reader endpoints provided by a PostgreSQL operator
+  or managed service;
+- use TLS with server verification and Secret-backed credentials;
+- grant the reader role only the permissions needed by reader-routed
+  operations where feasible;
+- monitor replica health and replay lag;
+- test failover and recovery behavior for the selected PostgreSQL platform.
+
 The pool settings apply independently to every process or Kubernetes pod. Calculate the connection budget separately for each PostgreSQL primary, including only clients that connect to that primary:
 
 ```text
@@ -89,6 +205,19 @@ required application connections =
 ```
 
 Non-BaSyx clients include identity services such as Keycloak when they share the database. The maximum concurrent replica count must include temporary old and new pods during rolling updates. Keep the total below that primary's usable connection budget and reserve connections for administration, monitoring, migrations, and failover. The maximum is a limit rather than a guarantee that every pool always opens that many connections, but PostgreSQL must be able to handle the configured worst case. Idle connections are still open PostgreSQL sessions.
+
+When a separate reader endpoint is configured, calculate its budget
+independently:
+
+```text
+required reader connections =
+  sum(reader.maxOpenConnections per BaSyx service × maximum concurrent replica count)
+  + non-BaSyx reader clients
+```
+
+Keep this total below the reader endpoint's usable connection budget and
+reserve capacity for monitoring, administration, and failover. More pools or
+connections do not add CPU, storage I/O, or replication capacity.
 
 All four pool values must be non-negative. An explicitly configured `maxIdleConnections` greater than the effective `maxOpenConnections` is rejected during startup. If `maxIdleConnections` is `0` and an explicit open limit is smaller than the default idle limit of `25`, the effective idle limit is capped at that smaller open limit.
 

--- a/docs/source/content/user_documentation/basyx_components/go/common/configuration.md
+++ b/docs/source/content/user_documentation/basyx_components/go/common/configuration.md
@@ -192,7 +192,9 @@ outage after startup is not silently routed to the writer. In production:
   or managed service;
 - use TLS with server verification and Secret-backed credentials;
 - grant the reader role only the permissions needed by reader-routed
-  operations where feasible;
+  operations where feasible. For endpoints that are not inherently read-only,
+  consider setting `postgres.reader.options` to
+  `-c default_transaction_read_only=on` as an additional guard;
 - monitor replica health and replay lag;
 - test failover and recovery behavior for the selected PostgreSQL platform.
 
@@ -221,7 +223,7 @@ connections do not add CPU, storage I/O, or replication capacity.
 
 All four pool values must be non-negative. An explicitly configured `maxIdleConnections` greater than the effective `maxOpenConnections` is rejected during startup. If `maxIdleConnections` is `0` and an explicit open limit is smaller than the default idle limit of `25`, the effective idle limit is capped at that smaller open limit.
 
-#### Optional CloudNativePG connection pooler
+#### Optional CloudNativePG read-write connection pooler
 
 ```{note}
 The `database.pooler` values require BaSyx Helm chart `3.7.0` or newer. They
@@ -337,6 +339,147 @@ Before enabling transaction pooling in production, render the chart against
 the installed CloudNativePG CRDs and test the deployed BaSyx version through
 the Pooler. Include bulk endpoints, large-object operations, connection
 saturation, rolling updates, and a PostgreSQL switchover.
+
+#### Helm reader configuration and read-only Pooler
+
+```{note}
+The `database.reader` values require BaSyx Helm chart `3.9.0` and BaSyx Go
+`1.0.7` or newer. Both the reader and its read-only Pooler are disabled by
+default.
+```
+
+For a database managed by the chart, enabling the global reader routes
+reader-eligible requests to the CloudNativePG read-only service
+`<database.clusterName>-ro`. Enabling its Pooler additionally creates a
+CloudNativePG `Pooler` of type `ro`, changes the reader endpoint to
+`<database.clusterName>-ro-pooler`, and leaves writer routing unchanged:
+
+```yaml
+database:
+  instances: 3
+  reader:
+    enabled: true
+    maxOpenConnections: 50
+    maxIdleConnections: 25
+    pooler:
+      enabled: true
+      instances: 2
+      monitoring:
+        enabled: true
+        labels:
+          release: kube-prometheus-stack
+```
+
+The global reader connection values are:
+
+| Key | Default | Purpose |
+| --- | --- | --- |
+| `database.reader.enabled` | `false` | Injects the optional reader connection into supported BaSyx Go services. |
+| `database.reader.existingSecret` | `""` | Complete external reader Secret. |
+| `database.reader.host` | `""` | External reader host override. |
+| `database.reader.port` | `""` | External reader port override. |
+| `database.reader.dbname` | `""` | External reader database-name override. |
+| `database.reader.user` | `""` | External reader user override. |
+| `database.reader.password` | `""` | External reader password override. |
+| `database.reader.sslmode` | `""` | Reader TLS mode override. |
+| `database.reader.sslcert` | `""` | Reader client-certificate path override. |
+| `database.reader.sslkey` | `""` | Reader client-key path override. |
+| `database.reader.sslrootcert` | `""` | Reader root-CA path override. |
+| `database.reader.connectTimeoutSeconds` | `0` | Reader connection-timeout override. |
+| `database.reader.applicationName` | `""` | Reader application-name override. |
+| `database.reader.fallbackApplicationName` | `""` | Reader fallback application-name override. |
+| `database.reader.searchPath` | `""` | Reader search-path override. |
+| `database.reader.options` | `""` | Reader PostgreSQL startup-options override. |
+| `database.reader.timezone` | `""` | Reader session-time-zone override. |
+| `database.reader.maxOpenConnections` | `50` | Reader pool's maximum open connections per BaSyx pod. |
+| `database.reader.maxIdleConnections` | `25` | Reader pool's maximum idle connections per BaSyx pod. |
+| `database.reader.connMaxLifetimeMinutes` | `5` | Reader connection lifetime. |
+| `database.reader.connMaxIdleTimeMinutes` | `0` | Reader idle lifetime; `0` disables idle-time recycling. |
+
+For an external database, `database.reader.existingSecret` selects a complete
+reader Secret. It must contain `host`, `port`, `dbname`, `user`, and `password`
+and can contain `sslmode`, `sslcert`, `sslkey`, `sslrootcert`,
+`connectTimeoutSeconds`, `applicationName`, `fallbackApplicationName`,
+`searchPath`, `options`, and `timezone`. Do not combine `existingSecret` with
+inline reader connection fields. Inline values are stored in a generated
+Secret. Any omitted inline field is deliberately sourced from the effective
+writer Secret. This makes a host-only override possible without duplicating
+credentials:
+
+```yaml
+database:
+  type: external
+  existingSecret: basyx-postgres-writer
+  reader:
+    enabled: true
+    host: postgres-reader.example.internal
+    sslmode: verify-full
+```
+
+Setting only `database.reader.enabled: true` for an external database points
+both pools to the same endpoint. This is valid for migration and compatibility
+but does not add database capacity. Prefer a complete existing reader Secret,
+TLS with server verification, and a least-privilege read-only role where
+feasible in production.
+
+Each charted BaSyx Go service supports a local override at
+`<component>.database.reader`:
+
+| Component value | Service |
+| --- | --- |
+| `aasDiscovery` | Discovery Service |
+| `aasRegistry` | AAS Registry |
+| `aasRepository` | AAS Repository |
+| `aasEnvironment` | AAS Environment |
+| `dppApi` | DPP API |
+| `submodelRegistry` | Submodel Registry |
+| `submodelRepository` | Submodel Repository |
+| `cdRepository` | Concept Description Repository |
+| `companyLookup` | Company Lookup Service |
+| `digitalTwinRegistry` | Digital Twin Registry |
+
+A service-local reader object replaces the global reader configuration. A
+reader-only local override continues to use the global writer. A service-local
+writer override without a local reader disables inherited global reader
+routing so that the service cannot accidentally read from a different
+database. The Configuration Service and Keycloak never receive the reader
+environment. The Go AASX File Server supports reader routing, but this chart
+does not currently deploy it.
+
+The read-only Pooler accepts the same capacity, prepared-statement, placement,
+and monitoring values as the read-write Pooler:
+
+- `database.reader.pooler.enabled`
+- `database.reader.pooler.instances`
+- `database.reader.pooler.poolMode`
+- `database.reader.pooler.maxClientConn`
+- `database.reader.pooler.defaultPoolSize`
+- `database.reader.pooler.preparedStatements.enabled`
+- `database.reader.pooler.preparedStatements.maxPreparedStatements`
+- `database.reader.pooler.parameters`
+- `database.reader.pooler.resources`
+- `database.reader.pooler.nodeSelector`
+- `database.reader.pooler.affinity`
+- `database.reader.pooler.tolerations`
+- `database.reader.pooler.topologySpreadConstraints`
+- `database.reader.pooler.monitoring.*`
+
+The schema rejects managed reader routing when `database.instances` is less
+than `2`, because there is no standby. It also rejects a read-only Pooler when
+the reader is disabled or when `database.type=external`. Its `PodMonitor`
+renders only when both the Pooler and its monitoring are enabled. It uses the
+`cnpg.io/poolerName` selector and supports the same labels, annotations,
+interval, timeout, namespace selector, relabelings, and metric relabelings as
+the read-write Pooler monitor. Prometheus Operator and its
+`monitoring.coreos.com/v1` CRDs must already be installed.
+
+Budget Pooler clients and PostgreSQL server connections separately. The sum of
+the reader pool limits across all BaSyx pods must fit within the surviving
+read-only Pooler instances' client capacity. The Pooler server-pool sizes,
+including every active user/database pair, must fit within the destination
+standby's `max_connections` with operational headroom. Monitor BaSyx
+`db.client.connections.*` metrics, `cnpg_pgbouncer_*` metrics, and PostgreSQL
+replication lag before increasing either limit.
 
 The DSN and database credentials are sensitive and should normally be supplied through a secret rather than committed to YAML.
 

--- a/docs/source/content/user_documentation/basyx_components/go/common/configuration.md
+++ b/docs/source/content/user_documentation/basyx_components/go/common/configuration.md
@@ -404,10 +404,10 @@ reader Secret. It must contain `host`, `port`, `dbname`, `user`, and `password`
 and can contain `sslmode`, `sslcert`, `sslkey`, `sslrootcert`,
 `connectTimeoutSeconds`, `applicationName`, `fallbackApplicationName`,
 `searchPath`, `options`, and `timezone`. Do not combine `existingSecret` with
-inline reader connection fields. Inline values are stored in a generated
-Secret. Any omitted inline field is deliberately sourced from the effective
-writer Secret. This makes a host-only override possible without duplicating
-credentials:
+inline reader connection fields. Inline reader connection values are stored in
+a generated Secret. Any omitted inline field is deliberately sourced from the
+effective writer Secret. This makes a host-only override possible without
+duplicating credentials:
 
 ```yaml
 database:

--- a/docs/source/content/user_documentation/basyx_components/go/common/configuration.md
+++ b/docs/source/content/user_documentation/basyx_components/go/common/configuration.md
@@ -352,7 +352,10 @@ For a database managed by the chart, enabling the global reader routes
 reader-eligible requests to the CloudNativePG read-only service
 `<database.clusterName>-ro`. Enabling its Pooler additionally creates a
 CloudNativePG `Pooler` of type `ro`, changes the reader endpoint to
-`<database.clusterName>-ro-pooler`, and leaves writer routing unchanged:
+`<database.clusterName>-ro-pooler`, and leaves writer routing unchanged. For
+long cluster names, the chart truncates the cluster-name portion of the Pooler
+service name to keep it within 63 characters and distinct from the
+CloudNativePG Cluster name:
 
 ```yaml
 database:
@@ -464,14 +467,17 @@ and monitoring values as the read-write Pooler:
 - `database.reader.pooler.topologySpreadConstraints`
 - `database.reader.pooler.monitoring.*`
 
-The schema rejects managed reader routing when `database.instances` is less
-than `2`, because there is no standby. It also rejects a read-only Pooler when
-the reader is disabled or when `database.type=external`. Its `PodMonitor`
-renders only when both the Pooler and its monitoring are enabled. It uses the
-`cnpg.io/poolerName` selector and supports the same labels, annotations,
-interval, timeout, namespace selector, relabelings, and metric relabelings as
-the read-write Pooler monitor. Prometheus Operator and its
-`monitoring.coreos.com/v1` CRDs must already be installed.
+The schema requires `database.instances` to be at least `2` when a managed
+reader implicitly targets the chart's native `<database.clusterName>-ro`
+service, because one instance provides no standby. A managed writer with one
+instance can still use an explicit reader `host` or `existingSecret`. The
+schema also rejects a read-only Pooler when the reader is disabled or when
+`database.type=external`. Its `PodMonitor` renders only when both the Pooler
+and its monitoring are enabled. It uses the `cnpg.io/poolerName` selector and
+supports the same labels, annotations, interval, timeout, namespace selector,
+relabelings, and metric relabelings as the read-write Pooler monitor.
+Prometheus Operator and its `monitoring.coreos.com/v1` CRDs must already be
+installed.
 
 Budget Pooler clients and PostgreSQL server connections separately. The sum of
 the reader pool limits across all BaSyx pods must fit within the surviving

--- a/docs/source/content/user_documentation/basyx_components/go/common/shared_features.md
+++ b/docs/source/content/user_documentation/basyx_components/go/common/shared_features.md
@@ -103,7 +103,10 @@ served by a standby or other read endpoint.
 
 Reader routing is based on consistency requirements, not on how many database
 queries a request executes. Results from a replicated reader are eventually
-consistent, including authorization-relevant resource changes. See
+consistent between requests, including authorization-relevant resource changes.
+When one response requires multiple SQL queries, those queries use one
+read-only repeatable-read transaction so that the response is assembled from
+one reader snapshot. See
 [General Configuration](configuration#optional-postgresql-reader) for the
 supported components, routing guarantees, security considerations, connection
 variables, and independent pool-sizing guidance.

--- a/docs/source/content/user_documentation/basyx_components/go/common/shared_features.md
+++ b/docs/source/content/user_documentation/basyx_components/go/common/shared_features.md
@@ -92,3 +92,18 @@ An explicitly configured idle limit greater than the effective open limit is rej
 If `applicationName` and the DSN do not define a PostgreSQL `application_name`, the service name is used automatically. Explicit values are preserved. This makes per-service connections visible in `pg_stat_activity`.
 
 See [General Configuration](configuration) for the full PostgreSQL configuration and budgeting guidance.
+
+## Optional PostgreSQL Reader Routing
+
+BaSyx Go 1.0.7 and later can open an independent PostgreSQL reader pool for
+eligible reads. Without reader configuration, the writer pool is reused and
+the behavior remains unchanged. With a reader configured, mutations and
+consistency-sensitive work stay on the writer while eligible reads can be
+served by a standby or other read endpoint.
+
+Reader routing is based on consistency requirements, not on how many database
+queries a request executes. Results from a replicated reader are eventually
+consistent, including authorization-relevant resource changes. See
+[General Configuration](configuration#optional-postgresql-reader) for the
+supported components, routing guarantees, security considerations, connection
+variables, and independent pool-sizing guidance.


### PR DESCRIPTION
## What changed

- document the optional `postgres.reader` connection and all `POSTGRES_READER_*` variables
- explain reader and writer routing across the PostgreSQL-backed BaSyx Go services
- document eventual consistency, stable per-response reader snapshots, authorization-relevant replica lag, startup behavior, and independent connection budgets
- add the BaSyx Helm chart 3.9.0 configuration for managed and external readers
- document global and service-local overrides, the CloudNativePG read-only Pooler, and its optional PodMonitor

## Version requirements

- BaSyx Go 1.0.7 or newer
- BaSyx Helm chart 3.9.0 or newer

The reader configuration depends on [eclipse-basyx/basyx-go-components#547](https://github.com/eclipse-basyx/basyx-go-components/pull/547) being included in BaSyx Go 1.0.7. The Helm section follows [eclipse-basyx/charts#92](https://github.com/eclipse-basyx/charts/pull/92). Both releases are still pending.

## Checks

- `git diff --check upstream/master...HEAD`
- Sphinx HTML build
